### PR TITLE
[codex] refactor dispatch phase 4 direct lifecycle wiring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ This repo is not the authority for Kuma-main-thread dispatch. Entry-point layeri
 - Kuma main thread (Claude) → `/kuma:dispatch` slash skill (orchestration wrapper only).
 - Worker / QA / Codex sub-worker → `kuma-task` + `kuma-dispatch ask|reply|complete|fail|qa-pass|qa-reject` directly.
 
-The CLI is the canonical worker-facing interface; `/kuma:dispatch` wraps it for Claude-main-only. No Codex slash-skill equivalent exists or is needed — the split is intentional.
+The CLI is the canonical worker-facing interface, and Phase 4 direct main dispatch uses `kuma-task` / `kuma-dispatch` as the canonical main-thread path as well. No Codex slash-skill equivalent exists or is needed — the split is intentional.
 
 ## Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,9 @@ The CLI is the canonical worker-facing interface, and Phase 4 direct main dispat
 - Server boot/restart is standardized on `npm run kuma-server:reload` for human/operator reuse of shared infra surfaces, and `npm run server:reload` as the raw in-surface/local entrypoint.
 - If the managed `kuma-server` surface already exists, restart the daemon there with `npm run kuma-server:reload` instead of starting a second server elsewhere.
 - If the managed `kuma-frontend` surface already exists, reuse it for `npm run dev:studio` instead of starting a second Vite dev server elsewhere.
+- Do not create or switch git branches unless the user explicitly instructs it.
+- Do not create git worktrees unless the user explicitly instructs it.
+- If branch/worktree isolation seems necessary to avoid conflicts, stop and ask for approval first.
 - Server code uses `.mjs` (ESM).
 - Frontend code uses TypeScript (`.ts`, `.tsx`).
 - Browser extension is vanilla JS, no build step.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,8 @@
 ## Dispatch Entry Points
 
 Entry-point layering (intentional, not drift):
-- Kuma main thread (Claude) → `/kuma:dispatch` slash skill (orchestration wrapper only — never call `kuma-task` directly from main thread).
-- Background Agent spawned by `/kuma:dispatch` → `kuma-task` + `kuma-dispatch` broker lifecycle.
+- Kuma main thread (Claude) → `kuma-task <worker> ...` + `kuma-dispatch` broker lifecycle directly.
+- Background polling/wait helpers are safety nets only and must not become the completion authority.
 - Worker / QA / Codex sub-worker → `kuma-task` + `kuma-dispatch ask|reply|complete|fail|qa-pass|qa-reject` directly. CLI is canonical; no slash-skill equivalent exists.
 
 ## Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@
 - **fallback/backfill 패턴 절대 금지.** 실패하면 실패로 보고. 자동 재전달/auto-redispatch/다른 소스에서 보충 절대 금지. SSOT 하나만 사용.
 - **서버 포트는 4312.** 3000/3001 아님. 확인 없이 포트 추측 금지.
 - **관리형 infra surface 우선.** `kuma-server`/`kuma-frontend` 가 있으면 거기서만 서버/프론트를 재시작한다. 현재 터미널에서 중복 기동 금지.
+- **브랜치/워크트리 임의 생성 금지.** 알렉스가 명시적으로 지시한 경우에만 새 git branch 또는 git worktree 를 만든다.
+- **충돌 회피 목적의 branch/worktree 도 사전 승인 필수.** 작업 충돌이 예상되면 이유를 먼저 보고하고 허가를 받은 뒤에만 분리한다.
 
 ## Dispatch Entry Points
 

--- a/packages/server/src/cmux-wait-script.test.mjs
+++ b/packages/server/src/cmux-wait-script.test.mjs
@@ -271,6 +271,7 @@ Wait for an exact signal file
         PATH: `${binDir}:${process.env.PATH}`,
         KUMA_AUTO_VAULT_INGEST: "0",
         KUMA_AUTO_NOEURI_TRIGGER: "0",
+        KUMA_DISABLE_VAULT_HOOK: "1",
         KUMA_SIGNAL_DIR: signalDir,
         KUMA_TASK_DIR: taskDir,
         KUMA_WAIT_POLL_INTERVAL: "1",
@@ -304,7 +305,25 @@ Wait for an exact signal file
     expect(exitCode).toBe(0);
     expect(stdout).toContain(`SIGNAL_RECEIVED: ${signalName}`);
     expect(stdout).toContain("exact match only");
-    expect(stderr).toBe("");
+    expect(stderr).not.toContain("false positive native wait");
+  });
+
+  it("rejects bare numeric positional timeout values instead of silently treating them as result files", async () => {
+    const root = await mkdtemp(join(tmpdir(), "kuma-cmux-wait-"));
+    tempRoots.push(root);
+
+    const signalDir = join(root, "signals");
+    await mkdir(signalDir, { recursive: true });
+
+    await expect(execFile("bash", [WAIT_SCRIPT_PATH, "demo-signal", "300"], {
+      env: {
+        ...process.env,
+        KUMA_SIGNAL_DIR: signalDir,
+      },
+    })).rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("Use --timeout 300 explicitly"),
+    });
   });
 
   it("dispatches a Noeuri follow-up and still exits 0 after successful auto ingest", async () => {

--- a/packages/server/src/kuma-agent-guard.test.mjs
+++ b/packages/server/src/kuma-agent-guard.test.mjs
@@ -1,0 +1,105 @@
+import { existsSync, readFileSync } from "node:fs";
+import { writeFile, unlink } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const KUMA_MODE_LOCK = "/tmp/kuma-mode-agent-guard-vitest.lock";
+const SPAWN_ALLOW_GLOB = "/tmp/kuma-agent-spawn-allow-vitest-*";
+const SPAWN_ALLOW_PATH = "/tmp/kuma-agent-spawn-allow-vitest-main";
+const SCRIPT_PATH = resolve(process.cwd(), "scripts/hooks/kuma-agent-guard.sh");
+
+let hadOriginalLock = false;
+let originalLockContents = null;
+
+async function runGuard(env = {}) {
+  return await new Promise((resolvePromise, reject) => {
+    const child = spawn("bash", [SCRIPT_PATH], {
+      env: {
+        ...process.env,
+        KUMA_ROLE: "master",
+        KUMA_MODE_LOCK_PATH: KUMA_MODE_LOCK,
+        KUMA_AGENT_SPAWN_ALLOW_GLOB: SPAWN_ALLOW_GLOB,
+        ...env,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolvePromise({ code, stdout, stderr });
+    });
+
+    child.stdin.end("{}");
+  });
+}
+
+describe.sequential("kuma-agent-guard", () => {
+  beforeAll(async () => {
+    hadOriginalLock = existsSync(KUMA_MODE_LOCK);
+    originalLockContents = hadOriginalLock ? readFileSync(KUMA_MODE_LOCK) : null;
+    if (!hadOriginalLock) {
+      await writeFile(KUMA_MODE_LOCK, "1\n", "utf8");
+    }
+
+    if (existsSync(SPAWN_ALLOW_PATH)) {
+      await unlink(SPAWN_ALLOW_PATH);
+    }
+  });
+
+  afterAll(async () => {
+    if (hadOriginalLock) {
+      await writeFile(KUMA_MODE_LOCK, originalLockContents);
+    } else if (existsSync(KUMA_MODE_LOCK)) {
+      await unlink(KUMA_MODE_LOCK);
+    }
+
+    if (existsSync(SPAWN_ALLOW_PATH)) {
+      await unlink(SPAWN_ALLOW_PATH);
+    }
+  });
+
+  it("blocks direct Agent usage without a scoped allow", async () => {
+    const result = await runGuard();
+
+    expect(result.code).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("scoped spawn allow");
+  });
+
+  it("allows workers without a scoped allow", async () => {
+    const result = await runGuard({ KUMA_ROLE: "worker" });
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('"continue": true');
+    expect(result.stderr).toBe("");
+  });
+
+  it("consumes a fresh scoped allow exactly once", async () => {
+    await writeFile(SPAWN_ALLOW_PATH, "kind: kuma-agent-spawn-allow\n", "utf8");
+
+    const first = await runGuard();
+    const second = await runGuard();
+
+    expect(first.code).toBe(0);
+    expect(first.stdout).toContain('"continue": true');
+    expect(first.stderr).toBe("");
+    expect(existsSync(SPAWN_ALLOW_PATH)).toBe(false);
+
+    expect(second.code).toBe(2);
+    expect(second.stdout).toBe("");
+    expect(second.stderr).toContain("scoped spawn allow");
+  });
+});

--- a/packages/server/src/kuma-bash-guard.test.mjs
+++ b/packages/server/src/kuma-bash-guard.test.mjs
@@ -5,14 +5,11 @@ import { resolve } from "node:path";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-const KUMA_MODE_LOCK = "/tmp/kuma-mode.lock";
-const KUMA_DISPATCH_LOCK = "/tmp/kuma-dispatch.lock";
+const KUMA_MODE_LOCK = "/tmp/kuma-mode-bash-guard-vitest.lock";
 const SCRIPT_PATH = resolve(process.cwd(), "scripts/hooks/kuma-bash-guard.sh");
 
 let hadOriginalLock = false;
 let originalLockContents = null;
-let hadOriginalDispatchLock = false;
-let originalDispatchLockContents = null;
 
 async function runGuard(command, env = {}) {
   return await new Promise((resolvePromise, reject) => {
@@ -20,6 +17,7 @@ async function runGuard(command, env = {}) {
       env: {
         ...process.env,
         KUMA_ROLE: "master",
+        KUMA_MODE_LOCK_PATH: KUMA_MODE_LOCK,
         ...env,
       },
       stdio: ["pipe", "pipe", "pipe"],
@@ -52,12 +50,6 @@ describe.sequential("kuma-bash-guard", () => {
     if (!hadOriginalLock) {
       await writeFile(KUMA_MODE_LOCK, "1\n", "utf8");
     }
-
-    hadOriginalDispatchLock = existsSync(KUMA_DISPATCH_LOCK);
-    originalDispatchLockContents = hadOriginalDispatchLock ? readFileSync(KUMA_DISPATCH_LOCK) : null;
-    if (!hadOriginalDispatchLock) {
-      await writeFile(KUMA_DISPATCH_LOCK, "1\n", "utf8");
-    }
   });
 
   afterAll(async () => {
@@ -65,12 +57,6 @@ describe.sequential("kuma-bash-guard", () => {
       await writeFile(KUMA_MODE_LOCK, originalLockContents);
     } else if (existsSync(KUMA_MODE_LOCK)) {
       await unlink(KUMA_MODE_LOCK);
-    }
-
-    if (hadOriginalDispatchLock) {
-      await writeFile(KUMA_DISPATCH_LOCK, originalDispatchLockContents);
-    } else if (existsSync(KUMA_DISPATCH_LOCK)) {
-      await unlink(KUMA_DISPATCH_LOCK);
     }
   });
 

--- a/packages/server/src/kuma-cli-bin.test.mjs
+++ b/packages/server/src/kuma-cli-bin.test.mjs
@@ -495,6 +495,16 @@ async function addSurfaceLabel(sandbox, projectId, label, surface) {
   await writeJson(sandbox.surfacesPath, registry);
 }
 
+async function removeSurfaceLabel(sandbox, projectId, label) {
+  const registry = await readJson(sandbox.surfacesPath);
+  if (!registry[projectId]) {
+    return;
+  }
+
+  delete registry[projectId][label];
+  await writeJson(sandbox.surfacesPath, registry);
+}
+
 async function setMemberDefaultQa(sandbox, memberId, defaultQa) {
   const team = await readJson(sandbox.teamPath);
   const member = team?.teams?.dev?.members?.find((entry) => entry.id === memberId);
@@ -503,6 +513,17 @@ async function setMemberDefaultQa(sandbox, memberId, defaultQa) {
   }
 
   member.defaultQa = defaultQa;
+  await writeJson(sandbox.teamPath, team);
+}
+
+async function setMemberQaFallback(sandbox, memberId, qaFallback) {
+  const team = await readJson(sandbox.teamPath);
+  const member = team?.teams?.dev?.members?.find((entry) => entry.id === memberId);
+  if (!member) {
+    throw new Error(`member not found in sandbox team.json: ${memberId}`);
+  }
+
+  member.qaFallback = qaFallback;
   await writeJson(sandbox.teamPath, team);
 }
 
@@ -842,6 +863,7 @@ describe("kuma CLI bin scripts", { timeout: 30_000 }, () => {
     expect(cmuxLog).toContain("Body source: dispatch lifecycle event");
     expect(cmuxLog).toContain("Recipient: Kuma (initiator, surface:99)");
     expect(cmuxLog).toContain("reported worker completion");
+    expect(cmuxLog).toContain("QA handoff target:");
     expect(cmuxLog).toContain("Broker status: worker-done");
   });
 
@@ -1314,6 +1336,71 @@ describe("kuma CLI bin scripts", { timeout: 30_000 }, () => {
     expect(stdout).toContain("QA: 밤토리 (surface:7)");
   });
 
+  it("kuma-task auto-spawns the primary QA reviewer when their surface is unregistered", async () => {
+    const sandbox = await setupCliSandbox();
+    tempRoots.push(sandbox.root);
+
+    await setMemberDefaultQa(sandbox, "tookdaki", "bamdori");
+    await removeSurfaceLabel(sandbox, "kuma-studio", "🦔 밤토리");
+
+    const { stdout, stderr } = await runScript(KUMA_TASK_PATH, ["뚝딱이", "echo test", "--project", "kuma-studio"], sandbox.env);
+
+    const taskFilePath = stdout.match(/TASK_FILE: (.+)/)?.[1];
+    const taskFile = await readFile(taskFilePath, "utf8");
+    const spawnLog = await readFile(sandbox.spawnLog, "utf8");
+    const registry = await readJson(sandbox.surfacesPath);
+    expect(taskFile).toContain("qa: surface:55");
+    expect(stdout).toContain("QA: 밤토리 (surface:55)");
+    expect(stderr).toContain("QA_ROUTE: 🦔 밤토리 -> auto-spawned surface:55");
+    expect(spawnLog).toContain("kuma-studio");
+    expect(registry["kuma-studio"]["🦔 밤토리"]).toBe("surface:55");
+  });
+
+  it("kuma-task reroutes busy QA reviewers to a fallback and auto-spawns the fallback when needed", async () => {
+    const sandbox = await setupCliSandbox();
+    tempRoots.push(sandbox.root);
+
+    await setMemberDefaultQa(sandbox, "tookdaki", "bamdori");
+    await setMemberQaFallback(sandbox, "tookdaki", "saemi");
+    await writeFile(join(sandbox.outputDir, "surface_7.txt"), "Investigating QA queue\n", "utf8");
+    await removeSurfaceLabel(sandbox, "kuma-studio", "🦅 새미");
+
+    const { stdout, stderr } = await runScript(KUMA_TASK_PATH, ["뚝딱이", "echo test", "--project", "kuma-studio"], sandbox.env);
+
+    const taskFilePath = stdout.match(/TASK_FILE: (.+)/)?.[1];
+    const taskFile = await readFile(taskFilePath, "utf8");
+    const spawnLog = await readFile(sandbox.spawnLog, "utf8");
+    const registry = await readJson(sandbox.surfacesPath);
+    expect(taskFile).toContain("qa: surface:55");
+    expect(stdout).toContain("QA: 새미 (surface:55)");
+    expect(stderr).toContain("QA_ROUTE: 밤토리 unavailable (state=working) -> rerouting to alternate reviewer saemi");
+    expect(stderr).toContain("QA_ROUTE: 🦅 새미 -> auto-spawned surface:55");
+    expect(spawnLog).toContain("kuma-studio");
+    expect(registry["kuma-studio"]["🦅 새미"]).toBe("surface:55");
+  });
+
+  it("kuma-task errors with primary and fallback QA states when both reviewers are unavailable", async () => {
+    const sandbox = await setupCliSandbox();
+    tempRoots.push(sandbox.root);
+
+    await setMemberDefaultQa(sandbox, "tookdaki", "bamdori");
+    await setMemberQaFallback(sandbox, "tookdaki", "saemi");
+    await writeFile(join(sandbox.outputDir, "surface_7.txt"), "Investigating QA queue\n", "utf8");
+    await writeFile(join(sandbox.outputDir, "surface_5.txt"), "Investigating fallback QA queue\n", "utf8");
+
+    let failure;
+    try {
+      await runScript(KUMA_TASK_PATH, ["뚝딱이", "echo test", "--project", "kuma-studio"], sandbox.env);
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeTruthy();
+    expect(failure.stderr).toContain(
+      "qa route unavailable: primary 밤토리 (surface=surface:7, state=working); fallback 새미 (surface=surface:5, state=working)",
+    );
+  });
+
   it("kuma-task does not prepend vault domain hints into the worker prompt by default", async () => {
     const sandbox = await setupCliSandbox();
     tempRoots.push(sandbox.root);
@@ -1383,6 +1470,7 @@ describe("kuma CLI bin scripts", { timeout: 30_000 }, () => {
     await writeFile(join(sandbox.outputDir, "surface_4.txt"), "Investigating sofa bug\n", "utf8");
     await writeFile(join(sandbox.outputDir, "surface_16.txt"), "❯\n", "utf8");
     await writeFile(join(sandbox.outputDir, "surface_7.txt"), "new task? /clear to save 12k tokens\n", "utf8");
+    await removeSurfaceLabel(sandbox, "kuma-studio", "🦅 새미");
 
     const { stdout } = await runScript(KUMA_STATUS_PATH, ["--project", "kuma-studio"], sandbox.env);
 
@@ -1390,6 +1478,7 @@ describe("kuma CLI bin scripts", { timeout: 30_000 }, () => {
     expect(stdout).toContain("kuma-studio\t🦫 뚝딱이\tsurface:4\tworking\tInvestigating sofa bug");
     expect(stdout).toContain("kuma-studio\t🦝 쿤\tsurface:16\tidle");
     expect(stdout).toContain("kuma-studio\t🦔 밤토리\tsurface:7\tidle");
+    expect(stdout).toContain("kuma-studio\t🦅 새미\t-\toffline\t");
   });
 
   it("kuma-status treats bypass-permissions footers as idle instead of working", async () => {

--- a/packages/server/src/kuma-cli-bin.test.mjs
+++ b/packages/server/src/kuma-cli-bin.test.mjs
@@ -806,9 +806,10 @@ describe("kuma CLI bin scripts", { timeout: 30_000 }, () => {
     expect(cmuxLog).toContain("Need API confirmation.");
   });
 
-  it("kuma-dispatch complete updates broker status without sending a lifecycle thread notice", async () => {
+  it("kuma-dispatch complete updates broker status and sends a direct lifecycle receive to the initiator without appending a thread notice", async () => {
     const sandbox = await setupCliSandbox();
     tempRoots.push(sandbox.root);
+    await addSurfaceLabel(sandbox, "kuma-studio", "Kuma", "surface:99");
 
     const { stdout } = await runScript(KUMA_TASK_PATH, ["뚝딱이", "echo test", "--project", "kuma-studio"], sandbox.env);
     const taskFilePath = stdout.match(/TASK_FILE: (.+)/)?.[1];
@@ -819,7 +820,8 @@ describe("kuma CLI bin scripts", { timeout: 30_000 }, () => {
       ["complete", "--task-file", taskFilePath],
       {
         ...sandbox.env,
-        KUMA_INITIATOR_SURFACE: "surface:4",
+        CMUX_SURFACE_ID: "surface:4",
+        KUMA_INITIATOR_SURFACE: "surface:99",
       },
     );
 
@@ -835,14 +837,18 @@ describe("kuma CLI bin scripts", { timeout: 30_000 }, () => {
     });
 
     const cmuxLog = await readFile(sandbox.cmuxLog, "utf8");
-    expect(cmuxLog).not.toContain("Message kind: status update");
-    expect(cmuxLog).not.toContain("Body source: dispatch lifecycle event");
-    expect(cmuxLog).not.toContain("completed work. Result:");
+    expect(cmuxLog).toContain("send-wrapper|surface:99");
+    expect(cmuxLog).toContain("Message kind: status update");
+    expect(cmuxLog).toContain("Body source: dispatch lifecycle event");
+    expect(cmuxLog).toContain("Recipient: Kuma (initiator, surface:99)");
+    expect(cmuxLog).toContain("reported worker completion");
+    expect(cmuxLog).toContain("Broker status: worker-done");
   });
 
-  it("kuma-dispatch qa-reject updates broker status without sending a lifecycle thread notice", async () => {
+  it("kuma-dispatch qa-reject updates broker status and sends a direct lifecycle receive to the initiator without appending a thread notice", async () => {
     const sandbox = await setupCliSandbox();
     tempRoots.push(sandbox.root);
+    await addSurfaceLabel(sandbox, "kuma-studio", "Kuma", "surface:99");
 
     const { stdout } = await runScript(KUMA_TASK_PATH, ["뚝딱이", "echo test", "--project", "kuma-studio"], sandbox.env);
     const taskFilePath = stdout.match(/TASK_FILE: (.+)/)?.[1];
@@ -853,7 +859,8 @@ describe("kuma CLI bin scripts", { timeout: 30_000 }, () => {
       ["qa-reject", "--task-file", taskFilePath, "--blocker", "Selection mismatch"],
       {
         ...sandbox.env,
-        KUMA_INITIATOR_SURFACE: "surface:7",
+        CMUX_SURFACE_ID: "surface:7",
+        KUMA_INITIATOR_SURFACE: "surface:99",
       },
     );
 
@@ -869,14 +876,18 @@ describe("kuma CLI bin scripts", { timeout: 30_000 }, () => {
     });
 
     const cmuxLog = await readFile(sandbox.cmuxLog, "utf8");
-    expect(cmuxLog).not.toContain("Message kind: blocker");
-    expect(cmuxLog).not.toContain("Body source: dispatch lifecycle event");
-    expect(cmuxLog).not.toContain("Selection mismatch. Result:");
+    expect(cmuxLog).toContain("send-wrapper|surface:99");
+    expect(cmuxLog).toContain("Message kind: blocker");
+    expect(cmuxLog).toContain("Body source: dispatch lifecycle event");
+    expect(cmuxLog).toContain("Recipient: Kuma (initiator, surface:99)");
+    expect(cmuxLog).toContain("Selection mismatch");
+    expect(cmuxLog).toContain("Broker status: qa-rejected");
   });
 
-  it("kuma-dispatch fail updates broker status without sending a lifecycle thread notice", async () => {
+  it("kuma-dispatch fail updates broker status and sends a direct lifecycle receive to the initiator without appending a thread notice", async () => {
     const sandbox = await setupCliSandbox();
     tempRoots.push(sandbox.root);
+    await addSurfaceLabel(sandbox, "kuma-studio", "Kuma", "surface:99");
 
     const { stdout } = await runScript(KUMA_TASK_PATH, ["뚝딱이", "echo test", "--project", "kuma-studio"], sandbox.env);
     const taskFilePath = stdout.match(/TASK_FILE: (.+)/)?.[1];
@@ -887,7 +898,8 @@ describe("kuma CLI bin scripts", { timeout: 30_000 }, () => {
       ["fail", "--task-file", taskFilePath, "--blocker", "Build broke"],
       {
         ...sandbox.env,
-        KUMA_INITIATOR_SURFACE: "surface:7",
+        CMUX_SURFACE_ID: "surface:4",
+        KUMA_INITIATOR_SURFACE: "surface:99",
       },
     );
 
@@ -903,14 +915,17 @@ describe("kuma CLI bin scripts", { timeout: 30_000 }, () => {
     });
 
     const cmuxLog = await readFile(sandbox.cmuxLog, "utf8");
-    expect(cmuxLog).not.toContain("Message kind: blocker");
-    expect(cmuxLog).not.toContain("Body source: dispatch lifecycle event");
-    expect(cmuxLog).not.toContain("reported a blocker:");
+    expect(cmuxLog).toContain("send-wrapper|surface:99");
+    expect(cmuxLog).toContain("Message kind: blocker");
+    expect(cmuxLog).toContain("Body source: dispatch lifecycle event");
+    expect(cmuxLog).toContain("Build broke");
+    expect(cmuxLog).toContain("Broker status: failed");
   });
 
-  it("kuma-dispatch qa-pass updates broker status without sending a lifecycle thread notice", async () => {
+  it("kuma-dispatch qa-pass updates broker status and sends a direct lifecycle receive to the initiator without appending a thread notice", async () => {
     const sandbox = await setupCliSandbox();
     tempRoots.push(sandbox.root);
+    await addSurfaceLabel(sandbox, "kuma-studio", "Kuma", "surface:99");
 
     const { stdout } = await runScript(KUMA_TASK_PATH, ["뚝딱이", "echo test", "--project", "kuma-studio"], sandbox.env);
     const taskFilePath = stdout.match(/TASK_FILE: (.+)/)?.[1];
@@ -921,7 +936,8 @@ describe("kuma CLI bin scripts", { timeout: 30_000 }, () => {
       ["qa-pass", "--task-file", taskFilePath],
       {
         ...sandbox.env,
-        KUMA_INITIATOR_SURFACE: "surface:7",
+        CMUX_SURFACE_ID: "surface:7",
+        KUMA_INITIATOR_SURFACE: "surface:99",
       },
     );
 
@@ -937,9 +953,11 @@ describe("kuma CLI bin scripts", { timeout: 30_000 }, () => {
     });
 
     const cmuxLog = await readFile(sandbox.cmuxLog, "utf8");
-    expect(cmuxLog).not.toContain("Message kind: status update");
-    expect(cmuxLog).not.toContain("Body source: dispatch lifecycle event");
-    expect(cmuxLog).not.toContain("passed QA. Result:");
+    expect(cmuxLog).toContain("send-wrapper|surface:99");
+    expect(cmuxLog).toContain("Message kind: status update");
+    expect(cmuxLog).toContain("Body source: dispatch lifecycle event");
+    expect(cmuxLog).toContain("passed QA");
+    expect(cmuxLog).toContain("Broker status: qa-passed");
   });
 
   it("kuma-dispatch reply defaults back to the worker surface from the initiator", async () => {

--- a/packages/server/src/studio/decision-detector.mjs
+++ b/packages/server/src/studio/decision-detector.mjs
@@ -1,5 +1,6 @@
 const FILLER_PATTERN = /^(?:아+|오+|어+|응+|엉+|음+|흠+|ㅋ+|ㅎㅎ+|하하+|lol|ok|ㅇ+)$|^(?:ㅇㅋ|오케이)\s*$/iu;
-const QUESTION_ENDING_PATTERN = /(?:\?$|[?？]|(?:할까|갈까|말까|둘까|볼까|할까요|갈까요|말까요|둘까요|볼까요)\s*$)/u;
+const QUESTION_ENDING_PATTERN = /(?:\?$|[?？]|(?:할까|갈까|말까|둘까|볼까|할까요|갈까요|말까요|둘까요|볼까요)(?:[.!。！？…]+)?\s*$)/u;
+const TRAILING_SENTENCE_PUNCTUATION_PATTERN = /[.!。！？…]+$/u;
 const APPROVE_PATTERNS = [
   /^(?:ㄱㄱ|ㄱ|ㅇㅋ|오케이|좋아|가자|확정|콜|진행해)$/u,
   /^(?:이걸로|이거로|그걸로|그거로)\s*(?:가|가자|확정|진행해)$/u,
@@ -8,22 +9,27 @@ const APPROVE_PATTERNS = [
 const REJECT_PATTERNS = [
   /^(?:ㄴㄴ|아냐|아니야|아님|그건 아님|하지 마|그건 말고|삭제)$/u,
   /^(?:이건|그건|저건)\s*(?:아냐|아님|말고)$/u,
+  /^(?:이건|그건|저건)\s+말고\s+삭제$/u,
 ];
 const HOLD_PATTERNS = [
-  /^(?:보류|나중에|일단 냅둬|일단 두자|미뤄|홀드)$/u,
+  /^(?:(?:이건|그건|저건)\s+)?(?:일단\s+)?(?:보류|나중에|냅둬|일단 냅둬|일단 두자|미뤄|홀드)$/u,
 ];
 const PRIORITY_PATTERNS = [
-  /^(?:이거|이게|이걸)\s*(?:먼저|우선)$/u,
+  /^(?:이거|이게|이걸)(?:를|는|은)?\s+먼저(?:\s+(?:해|하자|진행해|가자))?$/u,
   /^.+보다\s+.+먼저$/u,
   /^(?:이게 급함|이거 우선)$/u,
 ];
 const PREFERENCE_PATTERNS = [
   /^(?:앞으로 이렇게|다음부터 이렇게|항상 이렇게|절대 이렇게|기본값은 .+)$/u,
-  /^(?:다음부터|앞으로|항상|절대)\s+.+$/u,
+  /^(?:다음부터(?:는)?|앞으로(?:는)?|항상|절대)\s+.+$/u,
 ];
 
 function normalizeText(value) {
   return typeof value === "string" ? value.trim() : "";
+}
+
+function stripTrailingSentencePunctuation(text) {
+  return typeof text === "string" ? text.replace(TRAILING_SENTENCE_PUNCTUATION_PATTERN, "").trimEnd() : "";
 }
 
 function looksLikeQuestion(text) {
@@ -108,9 +114,10 @@ export function detectDecision({ text, precedingContext = null }) {
     return null;
   }
 
-  const matched = matchAction(originalText);
+  const canonicalText = stripTrailingSentencePunctuation(originalText);
+  const matched = matchAction(canonicalText);
   if (!matched && hasExplicitResponseContext(precedingContext)) {
-    const contextual = matchContextualAction(originalText);
+    const contextual = matchContextualAction(canonicalText);
     if (contextual) {
       return {
         matched: true,

--- a/packages/server/src/studio/decision-detector.test.mjs
+++ b/packages/server/src/studio/decision-detector.test.mjs
@@ -8,15 +8,20 @@ describe("decision-detector", () => {
     ["좋아", "approve"],
     ["이걸로 가", "approve"],
     ["이 방향으로 확정", "approve"],
+    ["이걸로 가.", "approve"],
     ["ㄴㄴ", "reject"],
     ["그건 말고", "reject"],
     ["하지 마", "reject"],
+    ["그건 말고 삭제.", "reject"],
     ["보류", "hold"],
     ["나중에", "hold"],
+    ["이건 일단 보류.", "hold"],
     ["이거 먼저", "priority"],
     ["A 보다 B 먼저", "priority"],
+    ["이거 먼저 해.", "priority"],
     ["앞으로 이렇게", "preference"],
     ["다음부터 이렇게", "preference"],
+    ["앞으로는 항상 kuma-picker 먼저 써.", "preference"],
   ])("detects %s as %s", (text, action) => {
     expect(detectDecision({ text })).toMatchObject({
       matched: true,
@@ -35,6 +40,7 @@ describe("decision-detector", () => {
     "이 함수를 호출한 다음 가자",
     "이거 먼저 볼까",
     "좋아?",
+    "앞으로는 이렇게 할까?",
     "다음부터 이렇게 할까",
   ])("filters anti-pattern or question text: %s", (text) => {
     expect(detectDecision({ text })).toBeNull();

--- a/packages/server/src/studio/studio-routes.team-config.test.mjs
+++ b/packages/server/src/studio/studio-routes.team-config.test.mjs
@@ -14,6 +14,7 @@ import { createTeamConfigRuntime } from "./team-config-runtime.mjs";
 import { createTeamConfigWatcherHandler } from "./team-config-watcher.mjs";
 
 const CMUX_SPAWN_SCRIPT_PATH = fileURLToPath(new URL("../../../../scripts/cmux/kuma-cmux-spawn.sh", import.meta.url));
+const CMUX_TEAM_CONFIG_SCRIPT_PATH = fileURLToPath(new URL("../../../../scripts/cmux/kuma-cmux-team-config.sh", import.meta.url));
 
 async function waitFor(assertion, timeoutMs = 4_000) {
   const startedAt = Date.now();
@@ -38,6 +39,11 @@ function writeExecutable(path, content) {
 }
 
 function createMinimalTeamSchema(overrides = {}) {
+  const { teams, ...memberOverrides } = overrides;
+  if (teams) {
+    return { teams };
+  }
+
   return {
     teams: {
       dev: {
@@ -58,7 +64,7 @@ function createMinimalTeamSchema(overrides = {}) {
             spawnType: "codex",
             spawnModel: "gpt-5.4-mini",
             spawnOptions: '--dangerously-bypass-approvals-and-sandbox -c service_tier=fast -c model_reasoning_effort="xhigh"',
-            ...overrides,
+            ...memberOverrides,
           },
         ],
       },
@@ -89,7 +95,7 @@ function createIdleTeamStatusStore() {
   };
 }
 
-function createFakeCmuxEnvironment(root, tempDirs) {
+function createFakeCmuxEnvironment(root, teamSchema = createMinimalTeamSchema()) {
   const binDir = join(root, "bin");
   mkdirSync(binDir, { recursive: true });
   const logPath = join(root, "cmux.log");
@@ -145,7 +151,7 @@ esac
   );
 
   const teamJsonPath = join(root, "team.json");
-  writeFileSync(teamJsonPath, `${JSON.stringify(createMinimalTeamSchema(), null, 2)}\n`, "utf8");
+  writeFileSync(teamJsonPath, `${JSON.stringify(teamSchema, null, 2)}\n`, "utf8");
 
   return {
     binDir,
@@ -733,17 +739,7 @@ describe("studio-routes team-config", () => {
     const fakeCmux = createFakeCmuxEnvironment(root);
     const result = spawnSync(
       "bash",
-      [
-        String(CMUX_SPAWN_SCRIPT_PATH),
-        "밤토리",
-        "",
-        root,
-        "kuma-studio",
-        "--workspace",
-        "workspace:9",
-        "--pane",
-        "pane:3",
-      ],
+      ["-lc", `source "${CMUX_TEAM_CONFIG_SCRIPT_PATH}" && build_member_command "밤토리" "" "${root}"`],
       {
         encoding: "utf8",
         env: fakeCmux.spawnEnv(),
@@ -751,19 +747,106 @@ describe("studio-routes team-config", () => {
     );
 
     assert.strictEqual(result.status, 0);
-    assert.match(result.stdout, /surface:123/u);
+    const command = result.stdout;
+    assert.match(command, /KUMA_ROLE=worker codex -m gpt-5\.4-mini/u);
+    assert.match(command, /developer_instructions=/u);
+    assert.match(command, /밤토리야\./u);
+    assert.match(command, /CoS\..*cmux worker management/u);
+    assert.match(command, /Wait for dispatched task/u);
+    assert.match(command, /--dangerously-bypass-approvals-and-sandbox/u);
+    assert.match(command, /-c service_tier=fast/u);
+    assert.match(command, /-c model_reasoning_effort="xhigh"/u);
+    expect(command).not.toMatch(/model_reasoning_effort="xhigh" CoS/u);
+    expect(command).not.toMatch(/kuma-picker/u);
+  }, 30_000);
 
-    const log = readFileSync(fakeCmux.logPath, "utf8");
-    assert.match(log, /send --workspace workspace:9 --surface surface:123/u);
-    assert.match(log, /KUMA_ROLE=worker codex -m gpt-5\.4-mini/u);
-    assert.match(log, /-c developer_instructions=/u);
-    assert.match(log, /CoS\.\\ Bash\\ execution\\,\\ cmux\\ worker\\ management/u);
-    assert.match(log, /Wait\\ for\\ dispatched\\ task/u);
-    assert.match(log, /--dangerously-bypass-approvals-and-sandbox/u);
-    assert.match(log, /-c service_tier=fast/u);
-    assert.match(log, /-c model_reasoning_effort="xhigh"/u);
-    expect(log).not.toMatch(/model_reasoning_effort="xhigh" CoS/u);
-    expect(log).not.toMatch(/kuma-picker/u);
+  it("spawns a system codex worker with member identity in developer instructions", () => {
+    const root = mkdtempSync(join(tmpdir(), "kuma-cmux-spawn-"));
+    tempDirs.push(root);
+
+    const fakeCmux = createFakeCmuxEnvironment(
+      root,
+      createMinimalTeamSchema({
+        teams: {
+          system: {
+            name: "시스템",
+            members: [
+              {
+                id: "noeuri",
+                name: "노을이",
+                emoji: "🦌",
+                role: "vault-manager",
+                roleLabel: {
+                  ko: "Vault 큐레이터",
+                  en: "Vault Curator. Knowledge management, curation, sync",
+                },
+                skills: ["kuma-vault"],
+                team: "system",
+                nodeType: "worker",
+                spawnType: "codex",
+                spawnModel: "gpt-5.4-mini",
+                spawnOptions: '--dangerously-bypass-approvals-and-sandbox -c service_tier=fast -c model_reasoning_effort="high"',
+              },
+            ],
+          },
+        },
+      }),
+    );
+    const result = spawnSync(
+      "bash",
+      ["-lc", `source "${CMUX_TEAM_CONFIG_SCRIPT_PATH}" && build_member_command "노을이" "" "${root}"`],
+      {
+        encoding: "utf8",
+        env: fakeCmux.spawnEnv(),
+      },
+    );
+
+    assert.strictEqual(result.status, 0);
+    const command = result.stdout;
+    assert.match(command, /KUMA_ROLE=worker codex -m gpt-5\.4-mini/u);
+    assert.match(command, /노을이야\./u);
+    assert.match(command, /Vault Curator\./u);
+  }, 30_000);
+
+  it("spawns the exact claude command with member identity in the startup prompt", () => {
+    const root = mkdtempSync(join(tmpdir(), "kuma-cmux-spawn-"));
+    tempDirs.push(root);
+
+    const fakeCmux = createFakeCmuxEnvironment(
+      root,
+      createMinimalTeamSchema({
+        id: "koon",
+        name: "쿤",
+        emoji: "🦝",
+        role: "ui",
+        roleLabel: {
+          ko: "퍼블리셔/디자이너",
+          en: "Publisher / Designer. HTML/CSS/Graphics",
+        },
+        skills: ["frontend-design"],
+        team: "dev",
+        nodeType: "worker",
+        spawnType: "claude",
+        spawnModel: "claude-opus-4-6",
+        spawnOptions: "--dangerously-skip-permissions",
+      }),
+    );
+    const result = spawnSync(
+      "bash",
+      ["-lc", `source "${CMUX_TEAM_CONFIG_SCRIPT_PATH}" && build_member_command "쿤" "" "${root}"`],
+      {
+        encoding: "utf8",
+        env: fakeCmux.spawnEnv(),
+      },
+    );
+
+    assert.strictEqual(result.status, 0);
+    const command = result.stdout;
+    assert.match(command, /KUMA_ROLE=worker claude --model claude-opus-4-6/u);
+    assert.match(command, /--append-system-prompt/u);
+    assert.match(command, /쿤야\./u);
+    assert.match(command, /Publisher \/ Designer\./u);
+    assert.match(command, /Do not respond unless there is a startup problem\./u);
   }, 30_000);
 
   it("passes workspace and title to tab rename and surfaces rename failures on stderr", () => {

--- a/packages/server/src/studio/studio-routes.team-config.test.mjs
+++ b/packages/server/src/studio/studio-routes.team-config.test.mjs
@@ -388,6 +388,7 @@ describe("studio-routes team-config", () => {
       queuePath,
       logPath,
       queuePollMs: 0,
+      resolveLiveMemberSurfacesFn: () => [],
     });
 
     try {
@@ -446,6 +447,7 @@ describe("studio-routes team-config", () => {
       queuePath,
       logPath,
       queuePollMs: 0,
+      resolveLiveMemberSurfacesFn: () => [],
       resolveWorkspaceForSurfaceFn: () => "workspace:2",
       resolvePaneForSurfaceFn: () => "pane:4",
       spawnRunner(scriptPath, args) {
@@ -518,6 +520,7 @@ describe("studio-routes team-config", () => {
     const runtime = createTeamConfigRuntime({
       queuePollMs: 0,
       selfWriteTtlMs: 10,
+      resolveLiveMemberSurfacesFn: () => [],
     });
 
     try {
@@ -578,6 +581,7 @@ describe("studio-routes team-config", () => {
       queuePath,
       logPath,
       queuePollMs: 0,
+      resolveLiveMemberSurfacesFn: () => [],
       resolveWorkspaceForSurfaceFn: () => "workspace:2",
       resolvePaneForSurfaceFn: () => "pane:4",
       spawnRunner() {
@@ -630,6 +634,7 @@ describe("studio-routes team-config", () => {
     const runtime = createTeamConfigRuntime({
       registryPath,
       queuePollMs: 0,
+      resolveLiveMemberSurfacesFn: () => [],
       resolveWorkspaceForSurfaceFn: () => "workspace:2",
       resolvePaneForSurfaceFn: () => "pane:4",
       killRunner(_scriptPath, surface) {
@@ -657,6 +662,65 @@ describe("studio-routes team-config", () => {
 
       assert.deepStrictEqual(calls, ["kill:surface:74", "spawn:🦔 밤토리"]);
       assert.strictEqual(result.surface, "surface:87");
+    } finally {
+      runtime.close();
+    }
+  });
+
+  it("falls back to live cmux surfaces for system member respawn when the registry misses", async () => {
+    const root = mkdtempSync(join(tmpdir(), "kuma-team-config-runtime-"));
+    tempDirs.push(root);
+
+    const registryPath = join(root, "surfaces.json");
+    writeFileSync(registryPath, `${JSON.stringify({ system: { "🐻 쿠마": "surface:1" } }, null, 2)}\n`, "utf8");
+
+    const calls = [];
+    const runtime = createTeamConfigRuntime({
+      registryPath,
+      queuePollMs: 0,
+      resolveLiveMemberSurfacesFn: () => ["surface:24", "surface:25"],
+      resolveWorkspaceForSurfaceFn: () => "workspace:5",
+      resolvePaneForSurfaceFn: () => "pane:9",
+      killRunner(_scriptPath, surface) {
+        calls.push(`kill:${surface}`);
+      },
+      spawnRunner(_scriptPath, args) {
+        calls.push(`spawn:${args.join(" ")}`);
+        return { status: 0, stdout: "surface:26\n", stderr: "", error: null };
+      },
+    });
+
+    try {
+      const result = runtime.respawnMember({
+        memberName: "노을이",
+        memberConfig: {
+          id: "noeuri",
+          emoji: "🦌",
+          team: "system",
+          type: "claude",
+        },
+        project: "system",
+        workspaceRoot: root,
+      });
+
+      assert.deepStrictEqual(calls, [
+        "kill:surface:24",
+        "kill:surface:25",
+        "spawn:🦌 노을이 claude " + root + " system --workspace workspace:5 --pane pane:9",
+      ]);
+      assert.deepStrictEqual(result, {
+        project: "system",
+        surface: "surface:26",
+        cleanupFailed: false,
+        cleanupError: null,
+        queued: false,
+      });
+      assert.deepStrictEqual(JSON.parse(readFileSync(registryPath, "utf8")), {
+        system: {
+          "🐻 쿠마": "surface:1",
+          "🦌 노을이": "surface:26",
+        },
+      });
     } finally {
       runtime.close();
     }
@@ -752,6 +816,7 @@ describe("studio-routes team-config", () => {
       queuePath,
       logPath,
       queuePollMs: 0,
+      resolveLiveMemberSurfacesFn: () => [],
       resolveWorkspaceForSurfaceFn: () => "workspace:2",
       resolvePaneForSurfaceFn: () => "pane:4",
       spawnRunner() {

--- a/packages/server/src/studio/team-config-runtime.mjs
+++ b/packages/server/src/studio/team-config-runtime.mjs
@@ -3,6 +3,8 @@ import { execFileSync, execSync, spawnSync } from "node:child_process";
 import { dirname } from "node:path";
 
 import {
+  buildRegistryLabel,
+  parseRegistryLabel,
   readSurfaceRegistryFile,
   removeRegistryMemberSurface,
   resolveRegistryMemberContext,
@@ -20,6 +22,52 @@ const DEFAULT_TEAM_RESPAWN_QUEUE_PATH = "/tmp/kuma-team-respawn-queue.json";
 const DEFAULT_TEAM_WATCHER_LOG_PATH = "/tmp/kuma-team-watcher.log";
 const DEFAULT_TEAM_RESPAWN_QUEUE_POLL_MS = 5_000;
 const SURFACE_NOT_FOUND_PATTERN = /(?:\bno such surface\b|\bsurface(?::\d+|\s+[^\n\r]+)?\s+not found\b)/iu;
+const CMUX_TREE_SURFACE_LINE_PATTERN = /surface\s+(surface:\d+)\s+\[[^\]]+\](?:\s+"([^"]*)")?/u;
+
+function titleMatchesMember(title, memberName, emoji = "") {
+  const normalizedTitle = String(title ?? "").trim();
+  const normalizedMemberName = String(memberName ?? "").trim();
+  const normalizedEmoji = String(emoji ?? "").trim();
+
+  if (!normalizedTitle || !normalizedMemberName) {
+    return false;
+  }
+
+  const parsed = parseRegistryLabel(normalizedTitle);
+  const canonicalLabel = buildRegistryLabel(normalizedMemberName, normalizedEmoji);
+
+  return (
+    normalizedTitle === normalizedMemberName
+    || normalizedTitle === canonicalLabel
+    || parsed.name === normalizedMemberName
+    || (normalizedEmoji && parsed.emoji === normalizedEmoji && parsed.name === normalizedMemberName)
+  );
+}
+
+function readLiveMemberSurfacesFromCmux(memberName, emoji = "") {
+  try {
+    const output = String(execSync("cmux tree 2>&1", withCmuxEnv({ encoding: "utf8" })));
+    const surfaces = [];
+
+    for (const line of output.split(/\r?\n/u)) {
+      const match = line.match(CMUX_TREE_SURFACE_LINE_PATTERN);
+      if (!match) {
+        continue;
+      }
+
+      const [, surface, title = ""] = match;
+      if (!titleMatchesMember(title, memberName, emoji)) {
+        continue;
+      }
+
+      surfaces.push(surface);
+    }
+
+    return Array.from(new Set(surfaces));
+  } catch {
+    return [];
+  }
+}
 
 function resolveWorkspaceForSurface(surface) {
   if (!/^surface:\d+$/u.test(surface)) {
@@ -143,10 +191,11 @@ export function createTeamConfigRuntime(options = {}) {
     queuePath = DEFAULT_TEAM_RESPAWN_QUEUE_PATH,
     logPath = DEFAULT_TEAM_WATCHER_LOG_PATH,
     queuePollMs = DEFAULT_TEAM_RESPAWN_QUEUE_POLL_MS,
-    selfWriteTtlMs = 3_000,
+    selfWriteTtlMs = 30_000,
     now = () => Date.now(),
     spawnRunner = defaultSpawnRunner,
     killRunner = defaultKillRunner,
+    resolveLiveMemberSurfacesFn = readLiveMemberSurfacesFromCmux,
     resolveWorkspaceForSurfaceFn = resolveWorkspaceForSurface,
     resolvePaneForSurfaceFn = resolvePaneForSurface,
   } = options;
@@ -179,25 +228,36 @@ export function createTeamConfigRuntime(options = {}) {
   };
   const getMemberStatus = (memberName) => findMemberStatus(teamStatusStore?.getSnapshot() ?? { projects: {} }, memberName);
   const logEvent = (message) => appendTeamWatcherLog(logPath, message);
-  const performRespawn = ({ memberName, memberConfig, project, currentSurface, workspaceRoot }) => {
+  const performRespawn = ({ memberName, memberConfig, project, currentSurface, cleanupSurfaces, workspaceRoot }) => {
     let cleanupFailed = false;
     let cleanupError = null;
+    const normalizedCleanupSurfaces = Array.from(
+      new Set(
+        [
+          currentSurface,
+          ...(Array.isArray(cleanupSurfaces) ? cleanupSurfaces : []),
+        ].filter((surface) => /^surface:\d+$/u.test(surface ?? "")),
+      ),
+    );
+    const primarySurface = normalizedCleanupSurfaces[0] ?? null;
 
     // Capture workspace/pane BEFORE kill — the surface must be alive to resolve these.
-    const workspace = currentSurface ? resolveWorkspaceForSurfaceFn(currentSurface) : null;
-    const pane = currentSurface ? resolvePaneForSurfaceFn(currentSurface) : null;
+    const workspace = primarySurface ? resolveWorkspaceForSurfaceFn(primarySurface) : null;
+    const pane = primarySurface ? resolvePaneForSurfaceFn(primarySurface) : null;
 
-    if (currentSurface) {
-      try {
-        killRunner(killScriptPath, currentSurface);
-      } catch (error) {
-        if (!isMissingSurfaceError(error)) {
-          cleanupFailed = true;
-          cleanupError = error instanceof Error ? error.message : "unknown error";
-          logEvent(
-            `RESPAWN_CLEANUP_FAILED: member=${memberName} surface=${currentSurface} details=${cleanupError}`,
-          );
-          throw error;
+    if (normalizedCleanupSurfaces.length > 0) {
+      for (const surface of normalizedCleanupSurfaces) {
+        try {
+          killRunner(killScriptPath, surface);
+        } catch (error) {
+          if (!isMissingSurfaceError(error)) {
+            cleanupFailed = true;
+            cleanupError = error instanceof Error ? error.message : "unknown error";
+            logEvent(
+              `RESPAWN_CLEANUP_FAILED: member=${memberName} surface=${surface} details=${cleanupError}`,
+            );
+            throw error;
+          }
         }
       }
 
@@ -209,40 +269,63 @@ export function createTeamConfigRuntime(options = {}) {
       writeSurfaceRegistryFile(registryPath, registryWithoutCurrent);
     }
 
-    const spawnArgs = [
+    const memberId = memberConfig?.id ?? memberName;
+    const baseSpawnArgs = [
       `${memberConfig?.emoji ? `${memberConfig.emoji} ` : ""}${memberName}`.trim(),
       memberConfig?.type ?? "",
       workspaceRoot,
       project,
     ];
 
-    if (currentSurface) {
-      if (workspace) {
-        spawnArgs.push("--workspace", workspace);
+    const runSpawn = (extraArgs) => {
+      const result = spawnRunner(spawnScriptPath, [...baseSpawnArgs, ...extraArgs]);
+      const stdout = String(result?.stdout ?? "").trim();
+      const stderr = String(result?.stderr ?? "").trim();
+      if (stderr) {
+        for (const line of stderr.split(/\r?\n/u).map((entry) => entry.trim()).filter(Boolean)) {
+          logEvent(line);
+        }
       }
-      if (pane) {
-        spawnArgs.push("--pane", pane);
-      }
+      const failed = result?.error != null || result?.status !== 0;
+      const nextSurface = stdout.match(/surface:\d+/u)?.[0] ?? "";
+      return { failed, error: result?.error ?? null, stdout, stderr, nextSurface };
+    };
+
+    const locationArgs = [];
+    if (primarySurface) {
+      if (workspace) locationArgs.push("--workspace", workspace);
+      if (pane) locationArgs.push("--pane", pane);
     }
 
-    const spawnResult = spawnRunner(spawnScriptPath, spawnArgs);
-    if (spawnResult?.error) {
-      throw spawnResult.error;
+    let attempt = runSpawn(locationArgs);
+    // If the placed spawn fails (stale workspace/pane after kill collapsed it), retry fresh.
+    if (attempt.failed && locationArgs.length > 0) {
+      logEvent(
+        `RESPAWN_FALLBACK: member=${memberName} reason=retry-without-location prev=${attempt.stderr || attempt.stdout || attempt.error?.message || "unknown"}`,
+      );
+      attempt = runSpawn([]);
     }
-    const output = String(spawnResult?.stdout ?? "").trim();
-    const stderr = String(spawnResult?.stderr ?? "").trim();
-    if (stderr) {
-      for (const line of stderr.split(/\r?\n/u).map((entry) => entry.trim()).filter(Boolean)) {
-        logEvent(line);
-      }
+
+    if (attempt.failed || !/^surface:\d+$/u.test(attempt.nextSurface)) {
+      // Old surface is dead and spawn failed. Queue for background retry
+      // (fresh spawn, no location) so the member isn't permanently orphaned.
+      queue[memberId] = {
+        memberId,
+        memberName,
+        project,
+        currentSurface: null,
+        requestedAt: new Date().toISOString(),
+        workspaceRoot,
+      };
+      persistQueue();
+      logEvent(
+        `RESPAWN_QUEUED_AFTER_FAILURE: member=${memberName} reason=spawn-failed details=${attempt.stderr || attempt.stdout || attempt.error?.message || "unknown"}`,
+      );
+      if (attempt.error) throw attempt.error;
+      throw new Error(`Failed to respawn ${memberName}: ${attempt.stderr || attempt.stdout || "spawn failed"}`);
     }
-    if (spawnResult?.status !== 0) {
-      throw new Error(`Failed to respawn ${memberName}: ${stderr || output || "spawn failed"}`);
-    }
-    const nextSurface = output.match(/surface:\d+/u)?.[0] ?? output;
-    if (!/^surface:\d+$/u.test(nextSurface)) {
-      throw new Error(`Failed to respawn ${memberName}: ${output || "missing surface id"}`);
-    }
+
+    const nextSurface = attempt.nextSurface;
 
     const nextRegistry = updateRegistryMemberSurface(
       readSurfaceRegistryFile(registryPath),
@@ -264,14 +347,35 @@ export function createTeamConfigRuntime(options = {}) {
   };
 
   const runtime = {
-    resolveMemberContext(memberName, emoji) {
-      return resolveRegistryMemberContext(
+    resolveLiveMemberSurfaces(memberName, emoji = "") {
+      return resolveLiveMemberSurfacesFn(memberName, emoji);
+    },
+    resolveMemberContext(memberName, emoji, requestedProject = "", team = "") {
+      const registryContext = resolveRegistryMemberContext(
         readSurfaceRegistryFile(registryPath),
         {
           displayName: memberName,
           emoji,
+          team,
         },
+        requestedProject,
       );
+
+      if (registryContext) {
+        return registryContext;
+      }
+
+      const liveSurfaces = runtime.resolveLiveMemberSurfaces(memberName, emoji);
+      const liveSurface = liveSurfaces[0] ?? null;
+      if (!liveSurface) {
+        return null;
+      }
+
+      return {
+        project: requestedProject || team || null,
+        label: buildRegistryLabel(memberName, emoji) || String(memberName ?? "").trim(),
+        surface: liveSurface,
+      };
     },
     registerPendingSelfWrite({ memberId, memberConfig, ttlMs = selfWriteTtlMs }) {
       if (!memberId) {
@@ -359,9 +463,12 @@ export function createTeamConfigRuntime(options = {}) {
       const nextRegistry = removeRegistryMemberSurface(readSurfaceRegistryFile(registryPath), memberName, emoji);
       writeSurfaceRegistryFile(registryPath, nextRegistry);
 
-      if (memberContext?.surface) {
+      for (const surface of Array.from(new Set([
+        memberContext?.surface ?? null,
+        ...runtime.resolveLiveMemberSurfaces(memberName, emoji),
+      ].filter(Boolean)))) {
         try {
-          killRunner(killScriptPath, memberContext.surface);
+          killRunner(killScriptPath, surface);
         } catch {
           // If the surface is already gone we still want the registry cleanup to stick.
         }
@@ -375,9 +482,19 @@ export function createTeamConfigRuntime(options = {}) {
       };
     },
     respawnMember({ memberName, memberConfig, project, currentSurface, workspaceRoot, deferIfWorking = true }) {
-      const memberContext = runtime.resolveMemberContext(memberName, memberConfig?.emoji);
+      const memberContext = runtime.resolveMemberContext(
+        memberName,
+        memberConfig?.emoji,
+        project,
+        memberConfig?.team,
+      );
       const nextProject = resolveProjectId(project, memberConfig, memberContext, workspaceRoot);
-      const nextCurrentSurface = currentSurface ?? memberContext?.surface ?? null;
+      const liveSurfaces = runtime.resolveLiveMemberSurfaces(memberName, memberConfig?.emoji);
+      const nextCurrentSurface = currentSurface ?? memberContext?.surface ?? liveSurfaces[0] ?? null;
+      const cleanupSurfaces = Array.from(new Set([
+        nextCurrentSurface,
+        ...liveSurfaces,
+      ].filter(Boolean)));
       const memberStatus = getMemberStatus(memberName);
       const memberId = memberConfig?.id ?? memberName;
 
@@ -404,6 +521,7 @@ export function createTeamConfigRuntime(options = {}) {
         memberConfig,
         project: nextProject,
         currentSurface: nextCurrentSurface,
+        cleanupSurfaces,
         workspaceRoot,
       });
       removeQueuedRespawn(memberId);

--- a/packages/shared/src/team-normalizer.test.mjs
+++ b/packages/shared/src/team-normalizer.test.mjs
@@ -43,6 +43,22 @@ async function runTeamConfigHelper(helperName, teamPath, args = [], extraEnv = {
     .filter(Boolean);
 }
 
+async function runTeamConfigHelperRaw(helperName, teamPath, args = [], extraEnv = {}) {
+  const { stdout } = await execFile(
+    "bash",
+    ["-lc", 'source "$1"; shift; "$@"', "bash", TEAM_CONFIG_SCRIPT_PATH, helperName, ...args],
+    {
+      env: {
+        ...process.env,
+        KUMA_TEAM_JSON_PATH: teamPath,
+        ...extraEnv,
+      },
+    },
+  );
+
+  return stdout.trimEnd();
+}
+
 describe("shared team normalizer", () => {
   const tempRoots = [];
 
@@ -349,18 +365,18 @@ describe("shared team normalizer", () => {
     await expect(runTeamConfigHelper("list_team_members", teamPath, ["dev", "worker"])).resolves.toEqual(["뚝딱이", "쿤"]);
   });
 
-  it("builds a Claude startup command that waits idle instead of auto-running a skill", async () => {
+  it("builds a Claude startup command that includes the member identity and waits idle", async () => {
     const root = await mkdtemp(join(tmpdir(), "kuma-team-normalizer-"));
     tempRoots.push(root);
 
     const teamPath = await writeTeamConfig(root, {
       teams: {
-        dev: {
+        system: {
           members: [
             {
-              id: "koon",
-              name: "쿤",
-              team: "dev",
+              id: "noeuri",
+              name: "노을이",
+              team: "system",
               spawnType: "claude",
               spawnModel: "claude-opus-4-6",
               spawnOptions: "--dangerously-skip-permissions",
@@ -372,18 +388,25 @@ describe("shared team normalizer", () => {
       },
     });
 
-    const [command] = await runTeamConfigHelper("build_member_command", teamPath, ["쿤", "", "/tmp/work"]);
+    const startupPrompt = await runTeamConfigHelperRaw(
+      "build_claude_startup_system_prompt",
+      teamPath,
+      ["노을이", "Publisher / Designer. HTML/CSS/Graphics", "worker"],
+    );
+    const [command] = await runTeamConfigHelper("build_member_command", teamPath, ["노을이", "", "/tmp/work"]);
     expect(command).toContain('claude --model claude-opus-4-6');
     expect(command).toContain("--append-system-prompt");
-    expect(command).toContain("Wait for dispatched task");
-    expect(command).toContain("Default to no legacy fallback paths.");
-    expect(command).toContain("Avoid nested conditional fallback chains.");
-    expect(command).toContain("Preserve SSOT and SRP:");
+    expect(startupPrompt).toContain("너의 이름은 노을이야.");
+    expect(startupPrompt).toContain("Publisher / Designer. HTML/CSS/Graphics");
+    expect(startupPrompt).toContain("Wait for dispatched task");
+    expect(startupPrompt).toContain("Default to no legacy fallback paths.");
+    expect(startupPrompt).toContain("Avoid nested conditional fallback chains.");
+    expect(startupPrompt).toContain("Preserve SSOT and SRP:");
     expect(command).not.toContain('"/frontend-design"');
-    expect(command).not.toContain('--\\ "/frontend-design"');
+    expect(command).not.toContain('-- "/frontend-design"');
   });
 
-  it("builds a Codex startup command with idle guard and without preferred skill injection", async () => {
+  it("builds a Codex startup command with the member identity, idle guard, and without preferred skill injection", async () => {
     const root = await mkdtemp(join(tmpdir(), "kuma-team-normalizer-"));
     tempRoots.push(root);
 
@@ -406,13 +429,20 @@ describe("shared team normalizer", () => {
       },
     });
 
+    const developerInstructions = await runTeamConfigHelperRaw(
+      "build_codex_developer_instructions",
+      teamPath,
+      ["밤토리", "QA. Build, deploy, screen verification. No code edits", "worker"],
+    );
     const [command] = await runTeamConfigHelper("build_member_command", teamPath, ["밤토리", "", "/tmp/work"]);
     expect(command).toContain('codex -m gpt-5.4-mini');
     expect(command).toContain("developer_instructions=");
-    expect(command).toContain("Wait\\ for\\ dispatched\\ task");
-    expect(command).toContain("Default\\ to\\ no\\ legacy\\ fallback\\ paths.");
-    expect(command).toContain("Remove\\ migration\\ scaffolding\\ as\\ soon\\ as\\ the\\ migration\\ is\\ complete.");
-    expect(command).toContain("Actively\\ delete\\ dead\\ code\\ and\\ legacy\\ code.");
+    expect(developerInstructions).toContain("너의 이름은 밤토리야.");
+    expect(developerInstructions).toContain("QA. Build, deploy, screen verification. No code edits");
+    expect(developerInstructions).toContain("Wait for dispatched task");
+    expect(developerInstructions).toContain("Default to no legacy fallback paths.");
+    expect(developerInstructions).toContain("Remove migration scaffolding as soon as the migration is complete.");
+    expect(developerInstructions).toContain("Actively delete dead code and legacy code.");
     expect(command).not.toContain("kuma-picker");
   });
 
@@ -439,11 +469,17 @@ describe("shared team normalizer", () => {
       },
     });
 
+    const developerInstructions = await runTeamConfigHelperRaw(
+      "build_codex_developer_instructions",
+      teamPath,
+      ["하울", "Operator. Task decomposition, dispatch, aggregation", "team"],
+    );
     const [command] = await runTeamConfigHelper("build_member_command", teamPath, ["하울", "", "/tmp/work"]);
     expect(command).toContain("developer_instructions=");
-    expect(command).toContain("Do\\ not\\ implement\\ directly\\ except\\ for\\ trivial\\ one-line\\ fixes.");
-    expect(command).toContain("Delegate\\ implementation\\ work\\ with\\ kuma-task.");
-    expect(command).toContain("Do\\ not\\ use\\ --trust-worker\\ when\\ dispatching\\ worker\\ tasks");
+    expect(developerInstructions).toContain("너의 이름은 하울야.");
+    expect(developerInstructions).toContain("Do not implement directly except for trivial one-line fixes.");
+    expect(developerInstructions).toContain("Delegate implementation work with kuma-task.");
+    expect(developerInstructions).toContain("Do not use --trust-worker when dispatching worker tasks");
   });
 
   it("resolves a registered member surface through the shell helper", async () => {

--- a/packages/shared/team-normalizer-cli.mjs
+++ b/packages/shared/team-normalizer-cli.mjs
@@ -45,6 +45,7 @@ function toShellMember(member) {
     team: member?.team ?? "",
     nodeType: member?.nodeType ?? "",
     defaultQa: member?.defaultQa ?? "",
+    qaFallback: member?.qaFallback ?? "",
     vaultDomains: Array.isArray(member?.vaultDomains) ? member.vaultDomains : [],
     defaultSurface: member?.defaultSurface ?? "",
     modelCatalogId: member?.modelCatalogId ?? "",

--- a/packages/shared/team-normalizer.mjs
+++ b/packages/shared/team-normalizer.mjs
@@ -323,6 +323,7 @@ export function normalizeTeam(teamId, team) {
  *   image: string,
  *   defaultSurface: string | null,
  *   defaultQa: string | null,
+ *   qaFallback: string | null,
  *   vaultDomains: string[],
  * }}
  */
@@ -364,6 +365,9 @@ export function normalizeTeamMember(teamId, member, modelCatalogById = new Map()
       : null,
     defaultQa: typeof member?.defaultQa === "string" && member.defaultQa.trim()
       ? member.defaultQa.trim()
+      : null,
+    qaFallback: typeof member?.qaFallback === "string" && member.qaFallback.trim()
+      ? member.qaFallback.trim()
       : null,
     vaultDomains: Array.isArray(member?.vaultDomains)
       ? member.vaultDomains

--- a/packages/studio-web/src/components/dashboard/DraggableDashboard.tsx
+++ b/packages/studio-web/src/components/dashboard/DraggableDashboard.tsx
@@ -357,10 +357,6 @@ export function DraggableDashboard({
       bodyUserSelectRef.current = document.body.style.userSelect;
       document.body.style.userSelect = "none";
       setDraggingId(dragSession.id);
-      setZIndices((currentZIndices) => ({
-        ...currentZIndices,
-        [dragSession.id]: nextZIndexRef.current++,
-      }));
     }
 
     const rect = container.getBoundingClientRect();
@@ -411,7 +407,19 @@ export function DraggableDashboard({
 
   const handlePanelMouseDown = useCallback(
     (id: string, event: ReactMouseEvent<HTMLDivElement>) => {
-      if (event.button !== 0 || shouldIgnoreDragStart(event.target as HTMLElement | null)) {
+      if (event.button !== 0) {
+        return;
+      }
+
+      // Raise this panel above its siblings on any interaction — a click on
+      // the body (e.g. expanding the CMUX dropdown) must not be covered by
+      // panels below. Without this, z-index only bumped after drag threshold.
+      setZIndices((current) => ({
+        ...current,
+        [id]: nextZIndexRef.current++,
+      }));
+
+      if (shouldIgnoreDragStart(event.target as HTMLElement | null)) {
         return;
       }
 

--- a/packages/studio-web/src/pages/StudioPage.tsx
+++ b/packages/studio-web/src/pages/StudioPage.tsx
@@ -310,7 +310,7 @@ export function StudioPage() {
       </div>
 
       {/* Top bar — Game HUD */}
-      <div className="game-hud-bar absolute top-0 left-0 right-0 z-30 flex items-center justify-between px-4 py-2">
+      <div className="game-hud-bar absolute top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-2">
         <div className="flex items-center gap-3">
           <span className="text-lg font-black tracking-tight text-amber-200" style={{ textShadow: "0 0 12px rgba(255, 200, 100, 0.4), 0 1px 3px rgba(0,0,0,0.4)" }}>쿠마 스튜디오</span>
           <span className="rounded-full bg-amber-400/20 text-amber-200 text-[10px] font-semibold px-2 py-0.5 border border-amber-400/25">{visibleCharacters.length}명</span>

--- a/prompts/kuma-system-prompt.md
+++ b/prompts/kuma-system-prompt.md
@@ -34,14 +34,14 @@ Dispatch policy:
 - Spawned workers start idle.
 - Actual work begins only after an explicit dispatch.
 - Completion and review outcomes must be reported through `kuma-dispatch`, not by touching ad-hoc signal files.
-- **Kuma team workers (Buri, Howl, Noeuri, Bamdori, etc.) are dispatched exclusively via the `/kuma:dispatch` skill.** That skill is the single abstraction for: dispatch.lock setup → Agent spawn → `kuma-task <worker>` invocation → signal wait → result + cleanup. Never bypass it with a raw `Agent(...)` call for Kuma worker dispatch.
-- When you invoke `/kuma:dispatch`, the skill already handles Agent configuration. Do not override `subagent_type` — the default (general-purpose) is correct. Do NOT use `codex:codex-rescue` or any `codex:*` subagent_type for Kuma worker dispatch, even for Codex-powered workers like Buri. Those `codex:*` agents are Anthropic plugin agents that pair Claude with Codex CLI in the current session — unrelated to Kuma cmux surface workers.
+- **Kuma team workers (Buri, Howl, Noeuri, Bamdori, etc.) are dispatched through the trusted CLI wrappers `kuma-task` and `kuma-dispatch`.** Main thread dispatch is direct `kuma-task <worker>`; completion authority stays with broker status + result file. Never bypass that with a raw `Agent(...)` call for Kuma worker dispatch.
+- If an Agent sub-agent is still used for adjacent orchestration work, do not override `subagent_type` unless the specific workflow requires it. Do NOT use `codex:codex-rescue` or any `codex:*` subagent_type for Kuma worker dispatch; those are unrelated Anthropic plugin agents.
 
 Dispatch entry points (layered, intentionally asymmetric):
-- **Kuma main thread (Claude)** → `/kuma:dispatch` — orchestration wrapper only. Never call `kuma-task` directly from the main thread.
-- **Background Agent spawned by `/kuma:dispatch`** → `kuma-task <worker>` + `kuma-dispatch` broker lifecycle. This is where the CLI layer is actually invoked.
+- **Kuma main thread (Claude)** → `kuma-task <worker>` + `kuma-dispatch` broker lifecycle directly.
+- **Background wait / polling helpers** → explicit `--timeout 300` safety net only. They are not the completion authority.
 - **Worker / QA / Codex sub-worker** → `kuma-task` + `kuma-dispatch ask|reply|complete|fail|qa-pass|qa-reject` directly. No slash-skill equivalent exists or is needed — the CLI is the canonical worker-facing interface.
 
 Sub-agent spawn policy:
 - When spawning any Agent sub-agent or background task that performs work on your behalf, the Agent prompt must inline the contents of `~/.kuma/prompts/subagent-behavior-rules.md` at the top. This keeps fallback/Playwright/SSOT/port/past-tense/raw-cmux rules enforced at the prompt layer even when execution-gate hooks are relaxed via dispatch lock.
-- The dispatch lock at `/tmp/kuma-dispatch.lock` relaxes `kuma-bash-guard`, `kuma-read-guard`, `kuma-agent-guard` for 10 minutes. Lock must be cleaned up by the dispatching agent on completion.
+- The dispatch lock at `/tmp/kuma-dispatch.lock` remains a temporary guard-relaxation mechanism only; it is not the canonical completion path or source of truth.

--- a/prompts/kuma-system-prompt.md
+++ b/prompts/kuma-system-prompt.md
@@ -25,6 +25,11 @@ Code cleanup policy:
 - Actively delete dead code and legacy code.
 - Preserve SSOT and SRP: keep one source of truth and one responsibility per module.
 
+Git branch/worktree policy:
+- Do not create or switch git branches unless 알렉스 explicitly instructs it.
+- Do not create git worktrees unless 알렉스 explicitly instructs it.
+- If branch/worktree isolation seems necessary to avoid conflicts, report the reason first and wait for approval.
+
 QA and browser policy:
 - Kuma Picker is the default path for screenshots and QA.
 - Playwright is only for Kuma Picker capability work or when the Kuma Picker policy explicitly allows it.

--- a/scripts/bin/kuma-dispatch
+++ b/scripts/bin/kuma-dispatch
@@ -37,8 +37,18 @@ json_field() {
     const fs = require("node:fs");
     const field = process.argv[1];
     const data = JSON.parse(fs.readFileSync(0, "utf8"));
-    const value = typeof data?.[field] === "string" ? data[field] : "";
-    process.stdout.write(`${value}\n`);
+    const segments = field.split(".").filter(Boolean);
+    let value = data;
+    for (const segment of segments) {
+      if (value == null || typeof value !== "object" || !(segment in value)) {
+        value = "";
+        break;
+      }
+      value = value[segment];
+    }
+    if (typeof value === "string") {
+      process.stdout.write(`${value}\n`);
+    }
   ' "$field"
 }
 
@@ -123,6 +133,33 @@ format_dispatch_party() {
   else
     printf '%s' "$display_label"
   fi
+}
+
+send_dispatch_prompt() {
+  local surface="${1:?surface required}"
+  local task_id="${2:?task id required}"
+  local speaker_label="${3:?speaker label required}"
+  local recipient_label="${4:?recipient label required}"
+  local kind_label="${5:?kind label required}"
+  local body_source_label="${6:?body source label required}"
+  local message_text="${7:?message text required}"
+  local footer="${8:-}"
+
+  local prompt
+  prompt="$(cat <<EOF
+[Kuma Studio Dispatch] ${task_id}
+Speaker: ${speaker_label}
+Recipient: ${recipient_label}
+Message kind: ${kind_label}
+Body source: ${body_source_label}
+
+${message_text}
+
+${footer}
+EOF
+)"
+
+  "$KUMA_CMUX_DIR/kuma-cmux-send.sh" "$surface" "$prompt"
 }
 
 resolve_dispatch_message_context() {
@@ -453,29 +490,138 @@ send_thread_message() {
   kind_label="$(dispatch_message_kind_label "$kind")"
   body_source_label="$(dispatch_body_source_label "$body_source")"
 
-  local prompt
-  prompt="$(cat <<EOF
-[Kuma Studio Dispatch] ${task_id}
-Speaker: ${speaker_label}
-Recipient: ${recipient_label}
-Message kind: ${kind_label}
-Body source: ${body_source_label}
-
-${message_text}
-
-Tracked task file: ${task_file}
+  send_dispatch_prompt \
+    "$to_surface" \
+    "$task_id" \
+    "$speaker_label" \
+    "$recipient_label" \
+    "$kind_label" \
+    "$body_source_label" \
+    "$message_text" \
+    "Tracked task file: ${task_file}
 Continue in-thread with:
-- ~/.kuma/bin/kuma-dispatch ask --task-file ${task_file} --message "..."
-- ~/.kuma/bin/kuma-dispatch reply --task-file ${task_file} --message "..."
-EOF
-)"
-
-  "$KUMA_CMUX_DIR/kuma-cmux-send.sh" "$to_surface" "$prompt"
+- ~/.kuma/bin/kuma-dispatch ask --task-file ${task_file} --message \"...\"
+- ~/.kuma/bin/kuma-dispatch reply --task-file ${task_file} --message \"...\""
 
   printf 'TASK_FILE: %s\n' "$task_file"
   printf 'TASK_ID: %s\n' "$task_id"
   printf 'FROM: %s (%s)\n' "$from_role" "$from_surface"
   printf 'TO: %s (%s)\n' "$to_role" "$to_surface"
+}
+
+dispatch_event_kind() {
+  case "${1:-}" in
+    fail|qa-reject)
+      printf 'blocker'
+      ;;
+    *)
+      printf 'status'
+      ;;
+  esac
+}
+
+format_lifecycle_notice() {
+  local dispatch_json="${1:?dispatch json required}"
+
+  printf '%s' "$dispatch_json" | node -e '
+    const fs = require("node:fs");
+    const payload = JSON.parse(fs.readFileSync(0, "utf8"));
+    const dispatch = payload?.dispatch ?? payload ?? {};
+
+    const normalize = (value) => (typeof value === "string" ? value.trim() : "");
+    const status = normalize(dispatch.status);
+    const lastEvent = normalize(dispatch.lastEvent);
+    const workerName = normalize(dispatch.workerName) || "Worker";
+    const qaMember = normalize(dispatch.qaMember) || "QA";
+    const blocker = normalize(dispatch.blocker) || normalize(dispatch.note);
+
+    let text = "";
+    if (status === "worker-done") {
+      text = `${workerName} reported worker completion. Read the result file and continue QA handoff.`;
+    } else if (status === "qa-passed" && lastEvent === "complete") {
+      text = `${workerName} completed work and broker recorded direct completion. Read the result file for the final report.`;
+    } else if (status === "qa-passed") {
+      text = `${qaMember} passed QA. Read the result file for the final report.`;
+    } else if (status === "qa-rejected") {
+      text = blocker
+        ? `${qaMember} rejected QA: ${blocker}. Read the result file and decide next action.`
+        : `${qaMember} rejected QA. Read the result file and decide next action.`;
+    } else if (status === "failed") {
+      text = blocker
+        ? `${workerName} reported a blocker: ${blocker}. Read the result file and decide next action.`
+        : `${workerName} reported a blocker. Read the result file and decide next action.`;
+    } else {
+      text = `${workerName} reported lifecycle status ${status || "unknown"}. Read the result file and broker status.`;
+    }
+
+    process.stdout.write(`${text}\n`);
+  '
+}
+
+emit_lifecycle_event_to_initiator() {
+  local event_type="${1:?event type required}"
+  local dispatch_json="${2:?dispatch json required}"
+
+  if [ ! -f "$KUMA_CMUX_DIR/kuma-cmux-send.sh" ]; then
+    printf 'LIFECYCLE_NOTICE_WARN: missing send wrapper %s\n' "$KUMA_CMUX_DIR/kuma-cmux-send.sh" >&2
+    return 0
+  fi
+
+  local current_surface
+  local kind
+  local context_json
+  local task_id
+  local task_file
+  local result_file
+  local broker_status
+  local from_role
+  local from_label
+  local from_surface
+  local to_role
+  local to_label
+  local to_surface
+  local speaker_label
+  local recipient_label
+  local kind_label
+  local body_source_label
+  local message_text
+
+  current_surface="$(resolve_dispatch_sender_surface)"
+  kind="$(dispatch_event_kind "$event_type")"
+  context_json="$(printf '%s' "$dispatch_json" | resolve_dispatch_message_context "$current_surface" "initiator" "$kind")"
+
+  task_id="$(printf '%s' "$context_json" | json_field taskId)"
+  task_file="$(printf '%s' "$dispatch_json" | json_field dispatch.taskFile)"
+  result_file="$(printf '%s' "$dispatch_json" | json_field dispatch.resultFile)"
+  broker_status="$(printf '%s' "$dispatch_json" | json_field dispatch.status)"
+  from_role="$(printf '%s' "$context_json" | json_field from)"
+  from_label="$(printf '%s' "$context_json" | json_field fromLabel)"
+  from_surface="$(printf '%s' "$context_json" | json_field fromSurface)"
+  to_role="$(printf '%s' "$context_json" | json_field to)"
+  to_label="$(printf '%s' "$context_json" | json_field toLabel)"
+  to_surface="$(printf '%s' "$context_json" | json_field toSurface)"
+
+  [ -n "$task_id" ] || return 0
+  [ -n "$to_surface" ] || return 0
+
+  speaker_label="$(format_dispatch_party "$from_label" "$from_role" "$from_surface")"
+  recipient_label="$(format_dispatch_party "$to_label" "$to_role" "$to_surface")"
+  kind_label="$(dispatch_message_kind_label "$kind")"
+  body_source_label="$(dispatch_body_source_label lifecycle-event)"
+  message_text="$(format_lifecycle_notice "$dispatch_json")"
+
+  send_dispatch_prompt \
+    "$to_surface" \
+    "$task_id" \
+    "$speaker_label" \
+    "$recipient_label" \
+    "$kind_label" \
+    "$body_source_label" \
+    "$message_text" \
+    "Tracked task file: ${task_file}
+Result file: ${result_file:-n/a}
+Broker status: ${broker_status:-unknown}
+Primary completion authority: broker status + result file"
 }
 
 run_dispatch_event() {
@@ -484,6 +630,7 @@ run_dispatch_event() {
 
   local dispatch_json=""
   dispatch_json="$(node "$KUMA_SERVER_CLI" "dispatch-${event_type}" "$@")"
+  emit_lifecycle_event_to_initiator "$event_type" "$dispatch_json"
   printf '%s\n' "$dispatch_json"
 }
 

--- a/scripts/bin/kuma-dispatch
+++ b/scripts/bin/kuma-dispatch
@@ -537,7 +537,7 @@ format_lifecycle_notice() {
 
     let text = "";
     if (status === "worker-done") {
-      text = `${workerName} reported worker completion. Read the result file and continue QA handoff.`;
+      text = `${workerName} reported worker completion. QA handoff target: ${qaMember}. Read the result file and continue QA handoff.`;
     } else if (status === "qa-passed" && lastEvent === "complete") {
       text = `${workerName} completed work and broker recorded direct completion. Read the result file for the final report.`;
     } else if (status === "qa-passed") {

--- a/scripts/bin/kuma-status
+++ b/scripts/bin/kuma-status
@@ -62,11 +62,16 @@ printf '%s' "$SNAPSHOT_JSON" | node -e '
     const members = Array.isArray(project?.members) ? project.members : [];
     for (const member of members) {
       const id = typeof member?.id === "string" ? member.id : "";
-      const surface = typeof member?.surface === "string" ? member.surface : "";
-      if (!id || !surface) continue;
+      const surface = typeof member?.surface === "string" && member.surface.trim() ? member.surface : "-";
+      if (!id) continue;
 
       const meta = byId.get(id) ?? { name: id, emoji: "", teamId: "" };
-      const state = typeof member?.state === "string" ? member.state : "idle";
+      const state =
+        typeof member?.state === "string" && member.state.trim()
+          ? member.state
+          : surface === "-"
+            ? "offline"
+            : "idle";
       const preview =
         (typeof member?.task === "string" && member.task.trim()) ||
         (Array.isArray(member?.lastOutputLines) && typeof member.lastOutputLines[0] === "string" ? member.lastOutputLines[0] : "") ||

--- a/scripts/bin/kuma-task
+++ b/scripts/bin/kuma-task
@@ -235,6 +235,78 @@ member_status_field() {
   ' "$field"
 }
 
+member_display_name_from_json() {
+  local member_json="${1:?member json required}"
+
+  printf '%s' "$member_json" | node -e '
+    const fs = require("node:fs");
+    const member = JSON.parse(fs.readFileSync(0, "utf8"));
+    process.stdout.write(`${member.displayName || member.name || member.id || ""}\n`);
+  '
+}
+
+member_id_from_json() {
+  local member_json="${1:?member json required}"
+
+  printf '%s' "$member_json" | node -e '
+    const fs = require("node:fs");
+    const member = JSON.parse(fs.readFileSync(0, "utf8"));
+    process.stdout.write(`${member.id || ""}\n`);
+  '
+}
+
+surface_id_from_json() {
+  local surface_json="${1:?surface json required}"
+
+  printf '%s' "$surface_json" | node -e '
+    const fs = require("node:fs");
+    const surface = JSON.parse(fs.readFileSync(0, "utf8"));
+    process.stdout.write(`${surface.surface || ""}\n`);
+  '
+}
+
+format_qa_candidate_summary() {
+  local role="${1:-candidate}"
+  local label="${2:-unknown}"
+  local surface="${3:-}"
+  local state="${4:-unknown}"
+  local reason="${5:-}"
+  local rendered_surface="${surface:--}"
+  local rendered_state="${state:-unknown}"
+
+  if [ -n "$reason" ]; then
+    printf '%s %s (surface=%s, state=%s, reason=%s)' "$role" "$label" "$rendered_surface" "$rendered_state" "$reason"
+  else
+    printf '%s %s (surface=%s, state=%s)' "$role" "$label" "$rendered_surface" "$rendered_state"
+  fi
+}
+
+spawn_member_surface_json() {
+  local project="${1:?project required}"
+  local member_json="${2:?member json required}"
+  local context="${3:-auto-spawn}"
+  local member_name=""
+  local member_label=""
+  local spawn_output=""
+  local surface=""
+
+  member_name="$(member_display_name_from_json "$member_json")"
+  member_label="$(member_display_label_from_json "$member_json")"
+  spawn_output="$("$SCRIPT_DIR/kuma-spawn" "$member_name" --project "$project" 2>&1)" || {
+    printf 'QA_ROUTE_WARN: failed to auto-spawn %s (%s): %s\n' "$member_label" "$context" "$spawn_output" >&2
+    return 1
+  }
+
+  surface="$(printf '%s\n' "$spawn_output" | awk -F': ' '/^SURFACE: /{print $2; exit}')"
+  if [ -z "$surface" ]; then
+    printf 'QA_ROUTE_WARN: auto-spawn for %s (%s) returned no SURFACE line\n' "$member_label" "$context" >&2
+    return 1
+  fi
+
+  printf 'QA_ROUTE: %s -> auto-spawned %s (%s)\n' "$member_label" "$surface" "$context" >&2
+  resolve_surface_json "$project" "$member_json"
+}
+
 dispatch_role_label() {
   case "${1:-}" in
     initiator)
@@ -451,28 +523,44 @@ else
       QA_LABEL="$(printf '%s' "$QA_MEMBER_JSON" | node -e 'const fs=require("node:fs"); const member=JSON.parse(fs.readFileSync(0,"utf8")); console.log(member.displayName);')"
       QA_DISPATCH_TARGET="$QA_LABEL"
       QA_SURFACE_JSON="$(resolve_surface_json "$PROJECT" "$QA_MEMBER_JSON" 2>/dev/null)" || QA_SURFACE_JSON=""
+      QA_MEMBER_ID="$(member_id_from_json "$QA_MEMBER_JSON")"
+      QA_STATUS="offline"
+      QA_PRIMARY_SUMMARY=""
+      QA_FALLBACK_SUMMARY="fallback none"
+      QA_NEEDS_FALLBACK=0
+      QA_PRIMARY_READY=0
 
-      # QA reroute: surface 가 없거나 busy 면 alternate QA 멤버로 전환
-      QA_BUSY=0
-      if [ -z "$QA_SURFACE_JSON" ]; then
-        QA_BUSY=1
-      else
-        QA_SURFACE="$(printf '%s' "$QA_SURFACE_JSON" | node -e 'const fs=require("node:fs"); const surface=JSON.parse(fs.readFileSync(0,"utf8")); console.log(surface.surface);')"
-        QA_MEMBER_ID="$(printf '%s' "$QA_MEMBER_JSON" | node -e 'const fs=require("node:fs"); const member=JSON.parse(fs.readFileSync(0,"utf8")); console.log(member.id);')"
+      if [ -n "$QA_SURFACE_JSON" ]; then
+        QA_SURFACE="$(surface_id_from_json "$QA_SURFACE_JSON")"
         QA_STATUS_JSON="$(read_project_member_status_json "$TEAM_STATUS_SNAPSHOT_JSON" "$QA_MEMBER_ID")"
         QA_STATUS="$(member_status_field "$QA_STATUS_JSON" state 2>/dev/null || echo "unknown")"
+        QA_PRIMARY_SUMMARY="$(format_qa_candidate_summary primary "$QA_LABEL" "$QA_SURFACE" "$QA_STATUS")"
         if [ "$QA_STATUS" = "working" ]; then
-          QA_BUSY=1
+          QA_NEEDS_FALLBACK=1
+        else
+          QA_PRIMARY_READY=1
+          QA_FRONTMATTER="$QA_SURFACE"
+        fi
+      else
+        QA_PRIMARY_SUMMARY="$(format_qa_candidate_summary primary "$QA_LABEL" "-" "offline" "unregistered")"
+        if QA_SURFACE_JSON="$(spawn_member_surface_json "$PROJECT" "$QA_MEMBER_JSON" "primary QA missing surface")"; then
+          QA_SURFACE="$(surface_id_from_json "$QA_SURFACE_JSON")"
+          QA_FRONTMATTER="$QA_SURFACE"
+          QA_PRIMARY_SUMMARY="$(format_qa_candidate_summary primary "$QA_LABEL" "$QA_SURFACE" "idle" "auto-spawned")"
+          QA_PRIMARY_READY=1
+        else
+          QA_NEEDS_FALLBACK=1
+          QA_PRIMARY_SUMMARY="$(format_qa_candidate_summary primary "$QA_LABEL" "-" "offline" "spawn-failed")"
         fi
       fi
 
-      if [ "$QA_BUSY" = "1" ]; then
-        # alternate QA 대상 조회 (worker의 qaFallback 필드)
+      if [ "$QA_NEEDS_FALLBACK" = "1" ]; then
         MEMBER_QA_FALLBACK="$(printf '%s' "$MEMBER_JSON" | node -e 'const fs=require("node:fs"); const m=JSON.parse(fs.readFileSync(0,"utf8")); console.log(m.qaFallback || "");' 2>/dev/null || echo "")"
         if [ -n "$MEMBER_QA_FALLBACK" ] && [ "$MEMBER_QA_FALLBACK" != "$QA_TARGET_QUERY" ]; then
-          printf 'QA_ROUTE: %s busy -> rerouting to alternate reviewer %s\n' "$QA_TARGET_QUERY" "$MEMBER_QA_FALLBACK" >&2
+          printf 'QA_ROUTE: %s unavailable (state=%s) -> rerouting to alternate reviewer %s\n' "$QA_LABEL" "$QA_STATUS" "$MEMBER_QA_FALLBACK" >&2
           case "$MEMBER_QA_FALLBACK" in
             self)
+              QA_FALLBACK_SUMMARY="$(format_qa_candidate_summary fallback worker-self-report "-" "trusted")"
               QA_MODE="self"
               QA_LABEL="worker-self-report"
               QA_FRONTMATTER="worker-self-report"
@@ -480,6 +568,7 @@ else
               QA_DISPATCH_TARGET=""
               ;;
             kuma-direct)
+              QA_FALLBACK_SUMMARY="$(format_qa_candidate_summary fallback kuma-direct "-" "direct")"
               QA_MODE="kuma-direct"
               QA_LABEL="kuma-direct"
               QA_FRONTMATTER="kuma-direct"
@@ -487,15 +576,39 @@ else
               QA_DISPATCH_TARGET=""
               ;;
             *)
-              QA_MEMBER_JSON="$(resolve_member_json "$MEMBER_QA_FALLBACK")" || die "qa reroute member not found: $MEMBER_QA_FALLBACK"
-              QA_DISPATCH_TARGET="$(printf '%s' "$QA_MEMBER_JSON" | node -e 'const fs=require("node:fs"); const member=JSON.parse(fs.readFileSync(0,"utf8")); console.log(member.displayName);')"
-              QA_LABEL="${QA_DISPATCH_TARGET}"
-              QA_SURFACE_JSON="$(resolve_surface_json "$PROJECT" "$QA_MEMBER_JSON" 2>/dev/null)" || die "qa reroute surface not found for $MEMBER_QA_FALLBACK"
-              QA_SURFACE="$(printf '%s' "$QA_SURFACE_JSON" | node -e 'const fs=require("node:fs"); const surface=JSON.parse(fs.readFileSync(0,"utf8")); console.log(surface.surface);')"
+              QA_FALLBACK_MEMBER_JSON="$(resolve_member_json "$MEMBER_QA_FALLBACK")" || die "qa reroute member not found: $MEMBER_QA_FALLBACK"
+              QA_FALLBACK_LABEL="$(printf '%s' "$QA_FALLBACK_MEMBER_JSON" | node -e 'const fs=require("node:fs"); const member=JSON.parse(fs.readFileSync(0,"utf8")); console.log(member.displayName);')"
+              QA_FALLBACK_MEMBER_ID="$(member_id_from_json "$QA_FALLBACK_MEMBER_JSON")"
+              QA_FALLBACK_SURFACE_JSON="$(resolve_surface_json "$PROJECT" "$QA_FALLBACK_MEMBER_JSON" 2>/dev/null)" || QA_FALLBACK_SURFACE_JSON=""
+              if [ -n "$QA_FALLBACK_SURFACE_JSON" ]; then
+                QA_FALLBACK_SURFACE="$(surface_id_from_json "$QA_FALLBACK_SURFACE_JSON")"
+                QA_FALLBACK_STATUS_JSON="$(read_project_member_status_json "$TEAM_STATUS_SNAPSHOT_JSON" "$QA_FALLBACK_MEMBER_ID")"
+                QA_FALLBACK_STATUS="$(member_status_field "$QA_FALLBACK_STATUS_JSON" state 2>/dev/null || echo "unknown")"
+                QA_FALLBACK_SUMMARY="$(format_qa_candidate_summary fallback "$QA_FALLBACK_LABEL" "$QA_FALLBACK_SURFACE" "$QA_FALLBACK_STATUS")"
+                if [ "$QA_FALLBACK_STATUS" = "working" ]; then
+                  die "qa route unavailable: ${QA_PRIMARY_SUMMARY}; ${QA_FALLBACK_SUMMARY}"
+                fi
+              elif QA_FALLBACK_SURFACE_JSON="$(spawn_member_surface_json "$PROJECT" "$QA_FALLBACK_MEMBER_JSON" "fallback QA missing surface")"; then
+                QA_FALLBACK_SURFACE="$(surface_id_from_json "$QA_FALLBACK_SURFACE_JSON")"
+                QA_FALLBACK_SUMMARY="$(format_qa_candidate_summary fallback "$QA_FALLBACK_LABEL" "$QA_FALLBACK_SURFACE" "idle" "auto-spawned")"
+              else
+                QA_FALLBACK_SUMMARY="$(format_qa_candidate_summary fallback "$QA_FALLBACK_LABEL" "-" "offline" "spawn-failed")"
+                die "qa route unavailable: ${QA_PRIMARY_SUMMARY}; ${QA_FALLBACK_SUMMARY}"
+              fi
+
+              QA_MEMBER_JSON="$QA_FALLBACK_MEMBER_JSON"
+              QA_DISPATCH_TARGET="$QA_FALLBACK_LABEL"
+              QA_LABEL="$QA_FALLBACK_LABEL"
+              QA_SURFACE_JSON="$QA_FALLBACK_SURFACE_JSON"
+              QA_SURFACE="$QA_FALLBACK_SURFACE"
               QA_FRONTMATTER="$QA_SURFACE"
               ;;
           esac
+        elif [ "$QA_PRIMARY_READY" != "1" ]; then
+          die "qa route unavailable: ${QA_PRIMARY_SUMMARY}; ${QA_FALLBACK_SUMMARY}"
         fi
+      elif [ "$QA_PRIMARY_READY" != "1" ]; then
+        die "qa route unavailable: ${QA_PRIMARY_SUMMARY}; ${QA_FALLBACK_SUMMARY}"
       fi
 
       QA_LABEL="${QA_LABEL:-$QA_TARGET_QUERY}"

--- a/scripts/cmux/kuma-cmux-team-config.sh
+++ b/scripts/cmux/kuma-cmux-team-config.sh
@@ -53,6 +53,10 @@ Code cleanup policy:
 - Remove migration scaffolding as soon as the migration is complete.
 - Actively delete dead code and legacy code.
 - Preserve SSOT and SRP: keep one source of truth and one responsibility per module.
+Git branch/worktree policy:
+- Do not create or switch git branches unless the user explicitly instructs it.
+- Do not create git worktrees unless the user explicitly instructs it.
+- If branch/worktree isolation seems necessary to avoid conflicts, stop and ask for approval first.
 EOF
 }
 

--- a/scripts/cmux/kuma-cmux-team-config.sh
+++ b/scripts/cmux/kuma-cmux-team-config.sh
@@ -28,8 +28,20 @@ json_stringify_string() {
   node -e 'process.stdout.write(JSON.stringify(process.argv[1] ?? ""))' "${1-}"
 }
 
+shell_single_quote() {
+  local value="${1-}"
+  value="${value//\'/\'\\\'\'}"
+  printf "'%s'" "$value"
+}
+
 build_idle_guard_message() {
   printf '%s' "$KUMA_IDLE_GUARD_MESSAGE"
+}
+
+build_member_identity_line() {
+  local member_name="${1:-}"
+  [ -n "$member_name" ] || return 0
+  printf '너의 이름은 %s야.' "$member_name"
 }
 
 build_cleanup_policy_instructions() {
@@ -195,24 +207,38 @@ resolve_member_launch_record() {
 }
 
 build_codex_developer_instructions() {
-  local role_label_en="${1:-}"
-  local node_type="${2:-worker}"
-  local instructions
+  local member_name="${1:-}"
+  local role_label_en="${2:-}"
+  local node_type="${3:-worker}"
+  local identity_line spawn_context instructions
 
-  instructions="$(build_spawn_context_instructions "$role_label_en" "$node_type")
-$(build_idle_guard_message)"
+  identity_line="$(build_member_identity_line "$member_name")"
+  spawn_context="$(build_spawn_context_instructions "$role_label_en" "$node_type")"
+  instructions="$(cat <<EOF
+${identity_line}
+${spawn_context}
+$(build_idle_guard_message)
+EOF
+)"
 
   printf '%s' "$instructions"
 }
 
 build_claude_startup_system_prompt() {
-  local role_label_en="${1:-}"
-  local node_type="${2:-worker}"
-  local instructions
+  local member_name="${1:-}"
+  local role_label_en="${2:-}"
+  local node_type="${3:-worker}"
+  local identity_line spawn_context instructions
 
-  instructions="$(build_spawn_context_instructions "$role_label_en" "$node_type")
+  identity_line="$(build_member_identity_line "$member_name")"
+  spawn_context="$(build_spawn_context_instructions "$role_label_en" "$node_type")"
+  instructions="$(cat <<EOF
+${identity_line}
+${spawn_context}
 $(build_idle_guard_message)
-Do not respond unless there is a startup problem."
+Do not respond unless there is a startup problem.
+EOF
+)"
 
   printf '%s' "$instructions"
 }
@@ -220,26 +246,29 @@ Do not respond unless there is a startup problem."
 build_member_command_from_record() {
   local dir="$1"
   local record="${2:?launch record required}"
-  local _name type model options _emoji skill role_label_en node_type developer_instructions developer_instructions_json startup_context command
-  IFS=$'\x1f' read -r _name type model options _emoji skill role_label_en node_type <<< "$record"
+  local member_name type model options _emoji skill role_label_en node_type developer_instructions developer_instructions_json startup_context command startup_context_quoted developer_instructions_setting
+  IFS=$'\x1f' read -r member_name type model options _emoji skill role_label_en node_type <<< "$record"
 
   case "$type" in
     claude)
-      startup_context="$(build_claude_startup_system_prompt "$role_label_en" "$node_type")"
-      printf -v command 'cd "%s" && KUMA_ROLE=worker claude --model %q %s --append-system-prompt %q' "$dir" "$model" "$options" "$startup_context"
+      startup_context="$(build_claude_startup_system_prompt "$member_name" "$role_label_en" "$node_type")"
+      startup_context_quoted="$(shell_single_quote "$startup_context")"
+      printf -v command 'cd "%s" && KUMA_ROLE=worker claude --model %q %s --append-system-prompt %s' "$dir" "$model" "$options" "$startup_context_quoted"
       ;;
     codex)
-      developer_instructions="$(build_codex_developer_instructions "$role_label_en" "$node_type")"
+      developer_instructions="$(build_codex_developer_instructions "$member_name" "$role_label_en" "$node_type")"
       if [ -n "$developer_instructions" ]; then
         developer_instructions_json="$(json_stringify_string "$developer_instructions")"
-        printf -v command 'cd "%s" && KUMA_ROLE=worker codex -m %q %s -c %q' "$dir" "$model" "$options" "developer_instructions=$developer_instructions_json"
+        developer_instructions_setting="$(shell_single_quote "developer_instructions=$developer_instructions_json")"
+        printf -v command 'cd "%s" && KUMA_ROLE=worker codex -m %q %s -c %s' "$dir" "$model" "$options" "$developer_instructions_setting"
       else
         printf -v command 'cd "%s" && KUMA_ROLE=worker codex -m %q %s' "$dir" "$model" "$options"
       fi
       ;;
     sonnet)
-      startup_context="$(build_claude_startup_system_prompt "$role_label_en")"
-      printf -v command 'cd "%s" && KUMA_ROLE=worker claude --model sonnet --dangerously-skip-permissions --append-system-prompt %q' "$dir" "$startup_context"
+      startup_context="$(build_claude_startup_system_prompt "$member_name" "$role_label_en" "$node_type")"
+      startup_context_quoted="$(shell_single_quote "$startup_context")"
+      printf -v command 'cd "%s" && KUMA_ROLE=worker claude --model sonnet --dangerously-skip-permissions --append-system-prompt %s' "$dir" "$startup_context_quoted"
       ;;
     *)
       echo "ERROR: Unknown type '$type'" >&2

--- a/scripts/cmux/kuma-cmux-wait.sh
+++ b/scripts/cmux/kuma-cmux-wait.sh
@@ -1420,6 +1420,10 @@ SIGNAL="${1:?signal name required}"
 shift
 
 if [ $# -gt 0 ] && [[ "$1" != --* ]]; then
+  if [[ "$1" =~ ^[0-9]+$ ]]; then
+    printf 'ERROR: bare numeric positional argument %s looks like a timeout. Use --timeout %s explicitly.\n' "$1" "$1" >&2
+    exit 1
+  fi
   RESULT_FILE="$1"
   shift
 fi

--- a/scripts/hooks/kuma-agent-guard.sh
+++ b/scripts/hooks/kuma-agent-guard.sh
@@ -1,6 +1,38 @@
 #!/bin/bash
+KUMA_MODE_LOCK_PATH="${KUMA_MODE_LOCK_PATH:-/tmp/kuma-mode.lock}"
+SPAWN_ALLOW_GLOB="${KUMA_AGENT_SPAWN_ALLOW_GLOB:-/tmp/kuma-agent-spawn-allow-*}"
+SPAWN_ALLOW_TTL_SECONDS="${KUMA_AGENT_SPAWN_ALLOW_TTL_SECONDS:-600}"
+
+consume_spawn_allow() {
+  local now
+  now=$(date +%s)
+
+  local allow_path
+  for allow_path in $SPAWN_ALLOW_GLOB; do
+    [ -e "$allow_path" ] || continue
+    [ -f "$allow_path" ] || continue
+
+    local allow_mtime
+    allow_mtime=$(stat -f %m "$allow_path" 2>/dev/null || echo "0")
+    local allow_age=$((now - allow_mtime))
+
+    if [ "$allow_age" -ge "$SPAWN_ALLOW_TTL_SECONDS" ]; then
+      rm -f "$allow_path"
+      continue
+    fi
+
+    local claim_path="${allow_path}.claimed.$$"
+    if mv "$allow_path" "$claim_path" 2>/dev/null; then
+      rm -f "$claim_path"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 # kuma 모드 아니면 통과
-if [ ! -f /tmp/kuma-mode.lock ]; then
+if [ ! -f "$KUMA_MODE_LOCK_PATH" ]; then
   echo '{"continue": true}'
   exit 0
 fi
@@ -11,15 +43,12 @@ if [ "$KUMA_ROLE" = "worker" ]; then
   exit 0
 fi
 
-# dispatch lock이 있으면 통과 (디스패치 스킬에서 서브에이전트 스폰용)
-if [ -f /tmp/kuma-dispatch.lock ]; then
-  lock_age=$(($(date +%s) - $(stat -f %m /tmp/kuma-dispatch.lock 2>/dev/null || echo "0")))
-  if [ "$lock_age" -lt 600 ]; then
-    echo '{"continue": true}'
-    exit 0
-  fi
+# dispatch entrypoint 전용 scoped allow가 있으면 1회 통과
+if consume_spawn_allow; then
+  echo '{"continue": true}'
+  exit 0
 fi
 
-# 그 외: 쿠마 모드에서 Agent 툴 사용 금지 — /kuma:dispatch 스킬을 먼저 사용할 것
-echo "⚠️ 쿠마는 Agent 직접 사용 금지. /kuma:dispatch 스킬로 dispatch lock을 먼저 생성한 뒤 서브에이전트를 스폰할 것."
+# 그 외: 쿠마 모드에서 Agent 툴 사용 금지 — trusted wrapper scoped allow 필요
+echo "⚠️ 쿠마는 Agent 직접 사용 금지. /kuma:dispatch 같은 trusted wrapper가 만든 scoped spawn allow 없이는 서브에이전트를 스폰할 수 없다." >&2
 exit 2

--- a/scripts/hooks/kuma-bash-guard.sh
+++ b/scripts/hooks/kuma-bash-guard.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # kuma-bash-guard v3 — 역할 분리 + early-return 구조
 # 쿠마 모드에서 Bash 직접 호출을 원칙적으로 금지
-# 워커 작업은 /kuma:dispatch 스킬 → 서브에이전트를 통해서만 실행
+# 워커/메인 dispatch는 trusted kuma-task / kuma-dispatch wrapper를 통해 실행
 
 # 쿠마 모드 아니면 통과
 if [ ! -f /tmp/kuma-mode.lock ]; then
@@ -42,6 +42,10 @@ if echo "$cmd" | grep -qE '(^|\s)(bash\s+)?(~/\.kuma/bin/)?kuma-(task|dispatch)(
   echo '{"continue": true}'; exit 0
 fi
 
+if echo "$cmd" | grep -qE '(^|\s)(bash\s+)?(~\/\.kuma\/cmux\/)?kuma-cmux-send\.sh(\s|$)'; then
+  echo '{"continue": true}'; exit 0
+fi
+
 # --- 항상 허용: 읽기전용 즉시 완료 명령 ---
 
 # kuma-status / kuma-kill / kuma-spawn-all / kuma-restart-all
@@ -71,5 +75,5 @@ if echo "$cmd" | grep -qE '^\s*cmux\s+(send|send-key)(\s|$)'; then
 fi
 
 # --- 전부 차단 ---
-echo "⚠️ 쿠마는 이 명령 직접 실행 금지. /kuma:dispatch 스킬을 사용해서 서브에이전트로 실행할 것. 직접 Bash는 차단됨." >&2
+echo "⚠️ 쿠마는 이 명령 직접 실행 금지. trusted wrapper(~/.kuma/bin/kuma-task 또는 ~/.kuma/bin/kuma-dispatch)를 사용할 것. 직접 Bash는 차단됨." >&2
 exit 2

--- a/scripts/hooks/kuma-bash-guard.sh
+++ b/scripts/hooks/kuma-bash-guard.sh
@@ -3,8 +3,10 @@
 # 쿠마 모드에서 Bash 직접 호출을 원칙적으로 금지
 # 워커/메인 dispatch는 trusted kuma-task / kuma-dispatch wrapper를 통해 실행
 
+KUMA_MODE_LOCK_PATH="${KUMA_MODE_LOCK_PATH:-/tmp/kuma-mode.lock}"
+
 # 쿠마 모드 아니면 통과
-if [ ! -f /tmp/kuma-mode.lock ]; then
+if [ ! -f "$KUMA_MODE_LOCK_PATH" ]; then
   echo '{"continue": true}'
   exit 0
 fi

--- a/scripts/hooks/kuma-user-prompt-capture.sh
+++ b/scripts/hooks/kuma-user-prompt-capture.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${KUMA_REPO_ROOT:-/Users/soohongkim/Documents/workspace/personal/kuma-studio}"
+
+# Kuma 모드가 아니면 아무 일도 하지 않는다.
+if [ ! -f /tmp/kuma-mode.lock ]; then
+  exit 0
+fi
+
+# 워커 세션은 캡처 대상이 아니다.
+if [ "${KUMA_ROLE:-}" = "worker" ]; then
+  exit 0
+fi
+
+HOOK_INPUT="$(cat)"
+
+KUMA_REPO_ROOT="$REPO_ROOT" \
+KUMA_VAULT_DIR="${KUMA_VAULT_DIR:-$HOME/.kuma/vault}" \
+KUMA_HOOK_INPUT="$HOOK_INPUT" \
+node --input-type=module <<'NODE'
+import { homedir } from "node:os";
+import { basename, join, relative, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+try {
+  function readHookInput() {
+    try {
+      return JSON.parse(process.env.KUMA_HOOK_INPUT || "{}");
+    } catch {
+      return null;
+    }
+  }
+
+  const input = readHookInput();
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    process.exit(0);
+  }
+
+  const prompt = typeof input.user_prompt === "string" ? input.user_prompt.trim() : "";
+  if (!prompt) {
+    process.exit(0);
+  }
+
+  const repoRoot = resolve(process.env.KUMA_REPO_ROOT || "/Users/soohongkim/Documents/workspace/personal/kuma-studio");
+  const projectDirSource = typeof input.cwd === "string" && input.cwd
+    ? input.cwd
+    : typeof process.env.CLAUDE_PROJECT_DIR === "string" && process.env.CLAUDE_PROJECT_DIR
+      ? process.env.CLAUDE_PROJECT_DIR
+      : "";
+  if (!projectDirSource) {
+    process.exit(0);
+  }
+
+  const projectDir = resolve(projectDirSource);
+  const relativeToRepo = relative(repoRoot, projectDir);
+  const insideRepo =
+    relativeToRepo === "" ||
+    (!relativeToRepo.startsWith("..") && !relativeToRepo.startsWith("/"));
+
+  if (!insideRepo) {
+    process.exit(0);
+  }
+
+  const vaultDir = process.env.KUMA_VAULT_DIR || join(homedir(), ".kuma", "vault");
+  const storeModule = await import(pathToFileURL(join(repoRoot, "packages/server/src/studio/decisions-store.mjs")).href);
+  const detectorModule = await import(pathToFileURL(join(repoRoot, "packages/server/src/studio/decision-detector.mjs")).href);
+
+  if (typeof storeModule?.appendDecision !== "function" || typeof detectorModule?.detectDecision !== "function") {
+    process.exit(0);
+  }
+
+  const detected = detectorModule.detectDecision({ text: prompt });
+  if (!detected) {
+    process.exit(0);
+  }
+
+  const scope = `project:${basename(repoRoot)}`;
+  const contextRef = typeof input.session_id === "string" && input.session_id.trim()
+    ? `session:${input.session_id.trim()}`
+    : "";
+
+  await storeModule.appendDecision({
+    vaultDir,
+    layer: "inbox",
+    entry: {
+      action: detected.action,
+      scope,
+      writer: "kuma-detect",
+      originalText: detected.original_text,
+      ...(contextRef ? { contextRef } : {}),
+      createdAt: new Date().toISOString(),
+    },
+  });
+} catch (error) {
+  if (error instanceof Error && error.message) {
+    console.error(`[kuma-user-prompt-capture] ${error.message}`);
+  }
+  process.exit(0);
+}
+NODE


### PR DESCRIPTION
## Summary
- route terminal dispatch lifecycle events directly back to the initiator surface while keeping broker status plus result file as the completion authority
- reject bare numeric positional args in kuma-cmux-wait so wrapper timeout wiring must use explicit --timeout 300
- update dispatch docs and targeted CLI tests for the Phase 4 direct-entrypoint contract

## Validation
- bash -n scripts/bin/kuma-dispatch scripts/cmux/kuma-cmux-wait.sh scripts/hooks/kuma-bash-guard.sh
- npx vitest run packages/server/src/kuma-cli-bin.test.mjs packages/server/src/cmux-wait-script.test.mjs packages/server/src/kuma-bash-guard.test.mjs